### PR TITLE
Easy performance improvements with strict foldl

### DIFF
--- a/src/Debug.hs
+++ b/src/Debug.hs
@@ -28,6 +28,6 @@ printState endState = do
   putTextLn "RunningBuilds:"
   mapM_
     (putTextLn <=< po . fst)
-    (foldr union mempty $ runningBuilds endState)
+    (foldl' union mempty $ runningBuilds endState)
   putTextLn "CompletedBuilds:"
-  mapM_ (putTextLn <=< po) (foldr union mempty $ completedBuilds endState)
+  mapM_ (putTextLn <=< po) (foldl' union mempty $ completedBuilds endState)

--- a/src/Print.hs
+++ b/src/Print.hs
@@ -121,7 +121,7 @@ stateToText now buildState@BuildState{..}
   downloadsDone = countPaths completedDownloads
 
 setAny :: (a -> Bool) -> Set a -> Bool
-setAny pred' = Set.foldr (\x y -> pred' x || y) False
+setAny pred' = Set.foldl' (\y x -> pred' x || y) False
 
 printHosts :: BuildState -> Bool -> Bool -> Bool -> [NonEmpty Entry]
 printHosts BuildState{runningBuilds, completedBuilds, completedDownloads, completedUploads} showBuilds showDownloads showUploads =

--- a/src/Table.hs
+++ b/src/Table.hs
@@ -30,7 +30,7 @@ displayWidth :: Text -> Int
 displayWidth = fst . Text.foldl widthFold (0, False)
 
 truncate :: Int -> Text -> Text
-truncate cut = either id (\(x,_,_) -> x) . Text.foldl (truncateFold cut) (Right ("",  0, False))
+truncate cut = either id (\(x,_,_) -> x) . Text.foldl' (truncateFold cut) (Right ("",  0, False))
 
 truncateFold :: Int -> Either Text (Text, Int, Bool) -> Char -> Either Text (Text, Int, Bool)
 truncateFold _ (Left x) _ = Left x
@@ -99,7 +99,7 @@ nextWidth sep rows = (width, chopWidthFromRows sep width rows)
 getWidthForNextColumn :: NonEmpty (NonEmpty Entry) -> Int
 getWidthForNextColumn = getWidthForColumn . fmap head
 getWidthForColumn :: NonEmpty Entry -> Int
-getWidthForColumn = foldr max 0 . fmap getRelevantWidthForEntry
+getWidthForColumn = foldl' max 0 . fmap getRelevantWidthForEntry
 getRelevantWidthForEntry :: Entry -> Int
 getRelevantWidthForEntry entry
   | span entry == 1 = entryWidth entry
@@ -116,7 +116,7 @@ chopWidthFromRow sep width (entry@Entry{span} :| rest)
 chopWidthFromRow _ _ (_ :| rest) = rest
 
 printRow :: Text -> [Int] -> NonEmpty Entry -> Text
-printRow sep colWidths entries = Text.intercalate sep $ snd (foldl foldFun (colWidths, id) entries) []
+printRow sep colWidths entries = Text.intercalate sep $ snd (foldl' foldFun (colWidths, id) entries) []
  where
   foldFun (colsLeft, line) entry@Entry{span} =
     (drop span colsLeft, line . (printEntry sep entry (take span colsLeft) :))

--- a/src/Update.hs
+++ b/src/Update.hs
@@ -269,6 +269,6 @@ building host drv now s@BuildState{outstandingBuilds, runningBuilds, buildReport
   lastNeeded = Map.lookup (host, getReportName drv) buildReports
 
 collapseMultimap :: Ord b => Map a (Set b) -> Set b
-collapseMultimap = Map.foldr (<>) mempty
+collapseMultimap = Map.foldl' (<>) mempty
 countPaths :: Ord b => Map a (Set b) -> Int
 countPaths = Set.size . collapseMultimap


### PR DESCRIPTION
Doesn't build up a thunk like `foldr` does or lazy `foldl`.