### PR TITLE
fix flickering display during high log traffic

### DIFF
--- a/src/IO.hs
+++ b/src/IO.hs
@@ -12,7 +12,7 @@ import qualified Data.Text as Text
 import Data.Text.Lazy as LText (Text)
 import Data.Text.Lazy.IO as LTextIO (getContents)
 import Data.Time (UTCTime, getCurrentTime)
-import System.Console.ANSI (SGR (Reset), clearFromCursorToScreenEnd, cursorUpLine, setSGRCode)
+import System.Console.ANSI (SGR (Reset), clearLine, cursorUpLine, setSGRCode)
 import System.Console.Terminal.Size (Window (Window), size)
 import System.IO (hFlush)
 
@@ -67,9 +67,9 @@ processText parser stateVar updater printerMay lazyInput = do
             buffer <- swapTVar bufferVar ""
             pure (writtenLines, buffer, linesToWrite, output)
           liftIO $ do
-            when (writtenLines > 0) do
-              cursorUpLine writtenLines
-              clearFromCursorToScreenEnd
+            replicateM_ writtenLines $ do
+              cursorUpLine 1
+              clearLine
             putText buffer
             when (linesToWrite > 0) $ putTextLn output
             hFlush stdout


### PR DESCRIPTION
to reduce flicker we want to avoid redraws of the terminal as much as possible.
since it seems that terminal emulators flush their display buffers immediately
when they see a screen clear command but hold on to them for further
modifications when the see a line clear command we'll just clear every line
individually and overwrite it from there. this could result in a small gap at
the end of the display if the nom table loses more rows than it receives output
lines in the same update cycle, but the same would've happened with screen clear too.

tested on urxvt and alacritty. on urxvt it eliminates flicker entirely, on alacritty it reduces it to very reasonable levels of maybe once per second.

fixes #24 