### PR TITLE
Generate flake for all default systems

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,7 @@
     pre-commit-hooks,
     ...
   }:
-    flake-utils.lib.eachSystem ["x86_64-linux"] (
+    flake-utils.lib.eachDefaultSystem (
       system: let
         ghc-version = "92";
         inherit (nixpkgs.legacyPackages.${system}) lib haskell pkgs;


### PR DESCRIPTION
Fixes: error: attribute 'aarch64-linux' missing