### PR TITLE
Fix display of large runtimes

### DIFF
--- a/lib/NOM/Print.hs
+++ b/lib/NOM/Print.hs
@@ -529,10 +529,16 @@ timeDiff :: Double -> Double -> Text
 timeDiff x =
   printDuration . realToFrac . (x -)
 
+minute :: NominalDiffTime
+minute = 60
+
+hour :: NominalDiffTime
+hour = 60 * minute
+
 printDuration :: NominalDiffTime -> Text
 printDuration diff
-  | diff < 60 = p "%Ss"
-  | diff < 60 * 60 = p "%Mm%Ss"
+  | diff < minute = p "%Ss"
+  | diff < hour = p "%Mm%Ss"
   | otherwise = p "%Hh%Mm%Ss"
  where
   p x = toText $ formatTime defaultTimeLocale x diff

--- a/lib/NOM/Print.hs
+++ b/lib/NOM/Print.hs
@@ -535,11 +535,15 @@ minute = 60
 hour :: NominalDiffTime
 hour = 60 * minute
 
+day :: NominalDiffTime
+day = 24 * hour
+
 printDuration :: NominalDiffTime -> Text
 printDuration diff
   | diff < minute = p "%Ss"
   | diff < hour = p "%Mm%Ss"
-  | otherwise = p "%Hh%Mm%Ss"
+  | diff < day = p "%Hh%Mm%Ss"
+  | otherwise = p "%dd%Hh%Mm%Ss"
  where
   p x = toText $ formatTime defaultTimeLocale x diff
 


### PR DESCRIPTION
This fixes the "modulo" display of runtimes beyond 24 hours by displaying those
as days, hours, minutes, seconds.

The format specifier was choosen in a way, that no modulo logic should apply
anymore and even runtimes beyond years should be displayed as (human unfriendly)
count of days.

Though this is really considered an unlikely edgecase.

Even the "week" which was the next unit of display in the formatting specifiers
is very unlikely and therefore not considered.

FIX #85 