### PR TITLE
Reset console state when terminating through SIGINT/SIGTERM

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -3,7 +3,7 @@
 , hermes-json, HUnit, lib, lock-file, MemoTrie, nix-derivation
 , optics, random, relude, safe, stm, streamly-core, strict
 , strict-types, terminal-size, text, time, transformers
-, typed-process, wcwidth, word8
+, typed-process, unix, wcwidth, word8
 }:
 mkDerivation {
   pname = "nix-output-monitor";
@@ -23,7 +23,7 @@ mkDerivation {
     data-default directory extra filepath hermes-json lock-file
     MemoTrie nix-derivation optics relude safe stm streamly-core strict
     strict-types terminal-size text time transformers typed-process
-    wcwidth word8
+    unix wcwidth word8
   ];
   testHaskellDepends = [
     ansi-terminal async attoparsec base bytestring cassava containers

--- a/nix-output-monitor.cabal
+++ b/nix-output-monitor.cabal
@@ -138,6 +138,7 @@ executable nom
   build-depends:
     , nix-output-monitor
     , typed-process
+    , unix
 
   autogen-modules: Paths_nix_output_monitor
 


### PR DESCRIPTION
```Nom alter the internal state of the underlying console it's running in.

Keeping track of the console current internal state through a IORef. It makes the state accessible for both the application and the signals handlers.

In the process of solving this issue, we introduce a custom signal handler in charge to reset the console and plug it to SIGINT and SIGTERM. This signal handler terminates the overall program by killing the main thread with exit code 1. The RTS runtime then kills the other thread for us before exiting itself with code 1.

Fixes https://github.com/maralorn/nix-output-monitor/issues/114
```

I don't have any nice automated test for this. I manually tested the patch using:

```
(nix-build test.nix; nix-build test.nix) |& cabal run nom
```

Where `test.nix` is just something really long to build:

```nix    
{ pkgs ? import <nixpkgs> {} }:

pkgs.stdenv.mkDerivation {
  pname = "test";
  version = "1";
  src = ./.;
  postInstall = ''
    sleep 100
  '';
}
```

I then send sigterm/sigint through htop to the nom process.

Note: I couldn't reproduce the initial issue @mic92 is facing. The cursor was properly reset on my setup when we kill Nom through SIGTERM. The cursor was not reset when killed via SIGINT though. This patch fixes this issue, killing with SIGINT now properly reset the terminal cursor. 

Fixes #114 