### PR TITLE
Fix table alignment

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -3,7 +3,7 @@
 , hermes-json, HUnit, lib, lock-file, MemoTrie, nix-derivation
 , optics, random, relude, safe, stm, streamly-core, strict
 , strict-types, terminal-size, text, time, transformers
-, typed-process, unix, wcwidth, word8
+, typed-process, unix, word8
 }:
 mkDerivation {
   pname = "nix-output-monitor";
@@ -16,21 +16,21 @@ mkDerivation {
     data-default directory extra filepath hermes-json lock-file
     MemoTrie nix-derivation optics relude safe stm streamly-core strict
     strict-types terminal-size text time transformers typed-process
-    wcwidth word8
+    word8
   ];
   executableHaskellDepends = [
     ansi-terminal async attoparsec base bytestring cassava containers
     data-default directory extra filepath hermes-json lock-file
     MemoTrie nix-derivation optics relude safe stm streamly-core strict
     strict-types terminal-size text time transformers typed-process
-    unix wcwidth word8
+    unix word8
   ];
   testHaskellDepends = [
     ansi-terminal async attoparsec base bytestring cassava containers
     data-default directory extra filepath hermes-json HUnit lock-file
     MemoTrie nix-derivation optics random relude safe stm streamly-core
     strict strict-types terminal-size text time transformers
-    typed-process wcwidth word8
+    typed-process word8
   ];
   homepage = "https://github.com/maralorn/nix-output-monitor";
   description = "Parses output of nix-build to show additional information";

--- a/lib/NOM/Print.hs
+++ b/lib/NOM/Print.hs
@@ -55,40 +55,21 @@ import Text.Printf (printf)
 showCode :: Text -> [String]
 showCode = map (printf "%02X" . fromEnum) . toString
 
-textRep, vertical, lowerleft, upperleft, horizontal, down, up, clock, running, done, bigsum, warning, todo, leftT, average :: Text
-textRep = fromString [toEnum 0xFE0E]
+vertical, lowerleft, upperleft, horizontal, down, up, clock, running, done, bigsum, warning, todo, leftT, average :: Text
 vertical = "┃"
 lowerleft = "┗"
 upperleft = "┏"
 leftT = "┣"
 horizontal = "━"
--- >>> showCode down
--- ["2193","FE0E"]
-down = "↓" <> textRep
--- >>> showCode up
--- ["2191","FE0E"]
-up = "↑" <> textRep
--- >>> showCode clock
--- ["23F1","FE0E"]
-clock = "⏱" <> textRep
--- >>> showCode running
--- ["25B6","FE0E"]
-running = "⏵" <> textRep
--- >>> showCode done
--- ["2714","FE0E"]
-done = "✔" <> textRep
--- >>> showCode todo
--- ["23F3","FE0E"]
-todo = "⏳" <> textRep
--- >>> showCode warning
--- ["26A0","FE0E"]
-warning = "⚠" <> textRep
--- >>> showCode average
--- ["2205","FE0E"]
-average = "∅" <> textRep
--- >>> showCode bigsum
--- ["2211","FE0E"]
-bigsum = "∑" <> textRep
+down = "↓"
+up = "↑"
+clock = "⏱"
+running = "⏵"
+done = "✔"
+todo = "⏸"
+warning = "⚠"
+average = "∅"
+bigsum = "∑"
 
 showCond :: (Monoid m) => Bool -> m -> m
 showCond = memptyIfFalse

--- a/lib/NOM/Print.hs
+++ b/lib/NOM/Print.hs
@@ -56,19 +56,47 @@ showCode :: Text -> [String]
 showCode = map (printf "%02X" . fromEnum) . toString
 
 vertical, lowerleft, upperleft, horizontal, down, up, clock, running, done, bigsum, warning, todo, leftT, average :: Text
+
+-- | U+2503 BOX DRAWINGS HEAVY VERTICAL
 vertical = "┃"
+
+-- | U+2517 BOX DRAWINGS HEAVY UP AND RIGHT
 lowerleft = "┗"
+
+-- | U+250F BOX DRAWINGS HEAVY DOWN AND RIGHT
 upperleft = "┏"
+
+-- | U+2523 BOX DRAWINGS HEAVY VERTICAL AND RIGHT
 leftT = "┣"
+
+-- | U+2501 BOX DRAWINGS HEAVY HORIZONTAL
 horizontal = "━"
+
+-- | U+2193 DOWNWARDS ARROW
 down = "↓"
+
+-- | U+2191 UPWARDS ARROW
 up = "↑"
+
+-- | U+23F1 STOPWATCH
 clock = "⏱"
+
+-- | U+23F5 BLACK MEDIUM RIGHT-POINTING TRIANGLE
 running = "⏵"
+
+-- | U+2714 HEAVY CHECK MARK
 done = "✔"
+
+-- | U+23F8 DOUBLE VERTICAL BAR
 todo = "⏸"
+
+-- | U+26A0 WARNING SIGN
 warning = "⚠"
+
+-- | U+2205 EMPTY SET
 average = "∅"
+
+-- | U+2211 N-ARY SUMMATION
 bigsum = "∑"
 
 showCond :: (Monoid m) => Bool -> m -> m

--- a/lib/NOM/Print/Table.hs
+++ b/lib/NOM/Print/Table.hs
@@ -71,8 +71,15 @@ truncateFold cut (Right (l, x, e)) c =
 widthFold :: (Int, Bool) -> Char -> (Int, Bool)
 widthFold (x, True) 'm' = (x, False)
 widthFold (x, True) _ = (x, True)
-widthFold (x, False) (fromEnum -> 27) = (x, True) -- Escape sequence
-widthFold (x, False) c = (x + wcwidth c, False)
+widthFold (x, False) (fromEnum -> 0x1b) = (x, True) -- Escape sequence
+widthFold (x, False) (fromEnum -> 0xfe0e) = (x, False) -- Variation selector 15, force text display
+widthFold (x, False) (fromEnum -> 0xfe0f) = (x, False) -- Variation selector 16, force emoji display
+widthFold (x, False) (fromEnum -> 0x23f3) = (x + 2, False) -- Clock symbol ⏳
+widthFold (x, False) c =
+  -- `wcwidth` sometimes returns -1.
+  -- See: https://github.com/maralorn/nix-output-monitor/issues/78
+  let width = wcwidth c
+   in (x + max width 1, False)
 
 dummy :: Entry
 dummy = text ""

--- a/lib/NOM/Print/Table.hs
+++ b/lib/NOM/Print/Table.hs
@@ -74,7 +74,7 @@ widthFold ::
 widthFold (x, True) 'm' = (x, False)
 widthFold (x, True) _ = (x, True)
 widthFold (x, False) (fromEnum -> 0x1b) = (x, True) -- Escape sequence
-widthFold (x, False) c = (x + 1, False)
+widthFold (x, False) _ = (x + 1, False)
 
 dummy :: Entry
 dummy = text ""

--- a/nix-output-monitor.cabal
+++ b/nix-output-monitor.cabal
@@ -85,7 +85,6 @@ common common-config
     , time
     , transformers
     , typed-process
-    , wcwidth
     , word8
 
   default-language:   GHC2021


### PR DESCRIPTION
This is at least a partial fix for #78. It works on my setup (macOS, iTerm2, tmux) but I'm curious if it performs well on `kitty` and others.

- No characters should have a width of -1 (`wcwidth` thinks that `⏱`, `⏳`, and `⏵` are all -1 cells wide)
- VS15 and VS16 should have a width of 0 (`wcwidth` thinks they're both 0 cells wide)
- ~~VS15 and VS16 go _before_ the codepoint they apply to, not after~~ I had this backwards, thanks @P1n3appl3 for pointing me to the docs.
- ⏳ should have a width of 2 (`wcwidth` thinks it's 1 cell wide)
  - This is the change I'm least sure about.

Before:
<img width="521" alt="Screenshot of nom showing a misaligned table" src="https://github.com/maralorn/nix-output-monitor/assets/15312184/c2819392-f4e6-46bb-b372-8fc970cf55bc">

After:
<img width="593" alt="Screenshot of nom showing a correctly aligned table" src="https://github.com/maralorn/nix-output-monitor/assets/15312184/7c586cfc-5cbb-435b-a4d9-3de0f5cf3dcb">

If you'd like to use this patch yourself, here's a nixpkgs overlay to apply it:

```nix
final: prev: {
  nix-output-monitor = prev.nix-output-monitor.overrideAttrs (old: {
    patches =
      (old.patches or [])
      ++ [
        (final.fetchpatch {
          url = "https://github.com/maralorn/nix-output-monitor/pull/121.diff";
          hash = "sha256-zASfg0Kp+zKhaJnnlGJ32HcX2K/NrBWAmvPVMm7/jCw=";
        })
      ];
  });
}
```
