### PR TITLE
feat: add bash completion

### DIFF
--- a/completions/completion.bash
+++ b/completions/completion.bash
@@ -1,0 +1,2 @@
+__load_completion nix
+complete -F _complete_nix nom

--- a/flake.nix
+++ b/flake.nix
@@ -25,6 +25,7 @@
           "stderr.json"
           "stdout.json"
           ".zsh"
+          ".bash"
           "LICENSE"
           "CHANGELOG.md"
           "default.nix"
@@ -50,6 +51,7 @@
                 ln -s nom "$out/bin/nom-shell"
                 chmod a+x $out/bin/nom-shell
                 installShellCompletion --zsh --name _nom-build completions/completion.zsh
+                installShellCompletion --bash --name _nom completions/completion.bash
               '';
             })
           ];

--- a/nix-output-monitor.cabal
+++ b/nix-output-monitor.cabal
@@ -17,6 +17,7 @@ author:             maralorn <mail@maralorn.de>
 maintainer:         maralorn <mail@maralorn.de>
 build-type:         Simple
 extra-source-files:
+  completions/completion.bash
   completions/completion.zsh
   test/golden/fail/stderr
   test/golden/fail/stderr.json


### PR DESCRIPTION
Note: this is just for the `nom <subcommand>` usage. But a similar trick can be used for `nom-build`.

Adds bash completion calling nix's and correcting the order of the args.

Another approach would be to call the normal bash nix completion but correct for the additional three arguments injected by nom, but this seems a bit cleaner to chain load the completion script.

Fixes: https://github.com/maralorn/nix-output-monitor/issues/31