### PR TITLE
Change links from git.maralorn.de to code.maralorn.de

### DIFF
--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -212,5 +212,5 @@ helpText =
     , "  --json     Parse input as nix internal-json"
     , ""
     , "Please see the readme for more details:"
-    , "https://git.maralorn.de/nix-output-monitor/about/"
+    , "https://code.maralorn.de/maralorn/nix-output-monitor/src/branch/main/README.md"
     ]

--- a/nix-output-monitor.cabal
+++ b/nix-output-monitor.cabal
@@ -32,7 +32,7 @@ category:
 
 source-repository head
   type:     git
-  location: https://git.maralorn.de/nix-output-monitor
+  location: https://code.maralorn.de/maralorn/nix-output-monitor.git
 
 common common-config
   default-extensions:


### PR DESCRIPTION
Likely this rotted in the switch to forgejo.