### PR TITLE
Replace ‘ with ' in help text to prevent encoding issues

### DIFF
--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -204,7 +204,7 @@ helpText =
     , "    via human-readable log parsing:"
     , "      nix-build |& nom"
     , ""
-    , "    Don‘t forget to redirect stderr, too. That's what the & does."
+    , "    Don't forget to redirect stderr, too. That's what the & does."
     , ""
     , "Flags:"
     , "  --version  Show version."


### PR DESCRIPTION
When `LOCALE_ARCHIVE` env variable is not set, `nom -h` fails like so

```
...
    via human-readable log parsing:
      nix-build |& nom

    Donnom: <stderr>: hPutChar: invalid argument (cannot encode character '\8216')
 ```
 
This is somewhat of a band-aid fix, but I'm not sure what part of this scary thing called "software stack" is at fault here and thus how this issue should be addressed properly.