### PR TITLE
Restyle "finished with traces" message

### DIFF
--- a/lib/NOM/Print.hs
+++ b/lib/NOM/Print.hs
@@ -251,7 +251,7 @@ stateToText config buildState@MkNOMV1State{..} = memo printWithSize . fmap Windo
   finishMarkup
     | numFailedBuilds > 0 = markup red . ((warning <> " Exited after " <> show numFailedBuilds <> " build failures") <>)
     | not (null nixErrors) = markup red . ((warning <> " Exited with " <> show (length nixErrors) <> " errors reported by nix") <>)
-    | not (null nixTraces) = markup yellow . ((warning <> " Exited with " <> show (length nixTraces) <> " traces reported by nix") <>)
+    | not (null nixTraces) = markup yellow . ((warning <> " Finished with " <> show (length nixTraces) <> " traces reported by nix") <>)
     | otherwise = markup green . ("Finished" <>)
   printHosts :: [NonEmpty Entry]
   printHosts =

--- a/lib/NOM/Print.hs
+++ b/lib/NOM/Print.hs
@@ -248,10 +248,15 @@ stateToText config buildState@MkNOMV1State{..} = memo printWithSize . fmap Windo
   downloadsRunning = CMap.size runningDownloads
   uploadsRunning = CMap.size runningUploads
   uploadsDone = CMap.size completedUploads
+  finishedWithTraces = mconcat
+    [ markup yellow warning
+    , markup green " Finished "
+    , markup yellow ("with " <> show (length nixTraces) <> " traces reported by nix")
+    ]
   finishMarkup
     | numFailedBuilds > 0 = markup red . ((warning <> " Exited after " <> show numFailedBuilds <> " build failures") <>)
     | not (null nixErrors) = markup red . ((warning <> " Exited with " <> show (length nixErrors) <> " errors reported by nix") <>)
-    | not (null nixTraces) = markup yellow . ((warning <> " Finished with " <> show (length nixTraces) <> " traces reported by nix") <>)
+    | not (null nixTraces) = (finishedWithTraces <>) . markup green
     | otherwise = markup green . ("Finished" <>)
   printHosts :: [NonEmpty Entry]
   printHosts =


### PR DESCRIPTION
Fixes #183. The first commit simply rewords the message, while the second restyles it so the main text is in green and the warning icon and traces text are in yellow.

![Screenshot 2025-03-06 at 2 55 09 PM](https://github.com/user-attachments/assets/ad7e342c-9f8b-4790-84d5-a71f70b66e00)