### PR TITLE
completions: add fish shell support

### DIFF
--- a/completions/nom-build.fish
+++ b/completions/nom-build.fish
@@ -1,0 +1,1 @@
+complete --command nom-build --wraps nix-build

--- a/completions/nom-shell.fish
+++ b/completions/nom-shell.fish
@@ -1,0 +1,1 @@
+complete --command nom-shell --wraps nix-shell

--- a/completions/nom.fish
+++ b/completions/nom.fish
@@ -1,0 +1,1 @@
+complete --command nom --wraps nix

--- a/flake.nix
+++ b/flake.nix
@@ -35,6 +35,7 @@
           "stdout.json"
           ".zsh"
           ".bash"
+          ".fish"
           "LICENSE"
           "CHANGELOG.md"
           "default.nix"


### PR DESCRIPTION
This PR adds completions for the fish shell by wrapping the commands `nix`, `nix-build` and `nix-shell`.

Currently the nix package in nixpkgs only provides completions for the `nix` command so only completions on the `nom` command works. Whenever the package provides completions for `nix-build` and `nix-shell` the wrappers for `nom-build` and `nom-shell` will pick up those completions as well.

The completions do not try to filter based on the subcommand so `nom search` is completed even though it doesn't seem to be supported by the `nom` command.