### PR TITLE
Fix build on systems other than x86_64-linux

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -48,13 +48,9 @@
             hlib.justStaticExecutables
             (hlib.appendConfigureFlag "--ghc-option=-Werror --ghc-option=-Wno-error=unrecognised-warning-flags")
 
-            (hlib.overrideCabal {
+            (hlib.overrideCabal ({
               src = cleanSelf;
-              doCheck = system == "x86_64-linux";
-              preCheck = ''
-                # ${lib.concatStringsSep ", " (golden-tests ++ map (x: x.drvPath) golden-tests)}
-                export TESTS_FROM_FILE=true;
-              '';
+              doCheck = false;
               buildTools = [ pkgs.installShellFiles ];
               postInstall = ''
                 ln -s nom "$out/bin/nom-build"
@@ -62,7 +58,13 @@
                 chmod a+x $out/bin/nom-shell
                 installShellCompletion completions/*
               '';
-            })
+            } // lib.optionalAttrs (system == "x86_64-linux") {
+              doCheck = true;
+              preCheck = ''
+                # ${lib.concatStringsSep ", " (golden-tests ++ map (x: x.drvPath) golden-tests)}
+                export TESTS_FROM_FILE=true;
+              '';
+            }))
           ];
         };
         checks = {


### PR DESCRIPTION
Running `nix build github:maralorn/nix-output-monitor` on/for systems other than `x86_64-linux` failed:

```
error: a 'x86_64-linux' with features {} is required to build '/nix/store/w5afkqmj662l56mcwmw5ijh1kfllxsap-build1.drv', but I am a 'aarch64-linux' with features {benchmark, big-parallel, kvm, nixos-test}
```

The `build1` is, if I understand correctly, a test fixture, and package already sets `doCheck = system == "x86_64-linux";`. The problem is, `preCheck` string references the test fixture derivation which are explicitly `x86_64-linux` only, so the package fails to evaluate on other systems (we don't even get a derivation to build).

This change splits the `overrideCabal` attrs into main part and conditional part: the conditional part includes both `doCheck = true;` and `preCheck`, and is added only for `x86_64-linux`. This makes the package build at least on `x86_64-linux` and `aarch64-linux` (I don't have other systems to test it).