### PR TITLE
Fix build-reports.csv only containing a single line

### DIFF
--- a/lib/NOM/Update/Monad/CacheBuildReports.hs
+++ b/lib/NOM/Update/Monad/CacheBuildReports.hs
@@ -14,7 +14,7 @@ import NOM.Builds (Host (..))
 import Relude
 import System.Directory (XdgDirectory (XdgCache), createDirectoryIfMissing, getXdgDirectory)
 import System.FileLock (SharedExclusive (Exclusive), withFileLock)
-import System.FilePath ((<.>), (</>))
+import System.FilePath ((</>))
 
 -- Exposed functions
 
@@ -53,7 +53,7 @@ tryUpdateBuildReports updateFunc = do
   dir <- buildReportsDir
   catchIO (createDirectoryIfMissing True dir) (const pass)
   withFileLock
-    (dir </> buildReportsFilename <.> "lock")
+    (dir </> buildReportsFilename)
     Exclusive
     (const $ updateBuildReportsUnlocked updateFunc dir)
 


### PR DESCRIPTION
Fixes #104.

Thanks to @Taneb for providing me with the changes to make here (once again, I really do not know Haskell).