### PR TITLE
workaround for hls and ghc 9.10.* crash

### DIFF
--- a/hls.json
+++ b/hls.json
@@ -1,0 +1,8 @@
+{
+    "plugin": {
+        "hlint": {
+            "codeActionsOn": false,
+            "diagnosticsOn": false
+        }
+    }
+}


### PR DESCRIPTION
Currently HLS does not work with this project by default because of https://github.com/haskell/haskell-language-server/issues/4674. This workaround disables the hlint plugin which makes HLS work within the project. This can be removed once we update to ghc 9.12.*