### PR TITLE
fix: attribute builds to remote store for ssh-ng builds

### DIFF
--- a/lib/NOM/NixMessage/JSON.hs
+++ b/lib/NOM/NixMessage/JSON.hs
@@ -85,6 +85,7 @@ makeFieldLabelsNoPrefix ''ActivityProgress
 
 data StartAction = MkStartAction
   { id :: ActivityId
+  , parent :: ActivityId
   , level :: Verbosity
   , text :: Text
   , activity :: Activity

--- a/lib/NOM/Parser/JSON.hs
+++ b/lib/NOM/Parser/JSON.hs
@@ -132,6 +132,7 @@ parseStartAction = do
   idField <- JSON.atKey "id" JSON.int
   text <- JSON.atKey "text" JSON.text
   level <- JSON.atKey "level" parseVerbosity
+  parentField <- JSON.atKey "parent" JSON.int
   activityType <- JSON.atKey "type" (JSON.withInt parseActivityType)
   let txt = textFields
   activity <- case activityType of
@@ -163,4 +164,4 @@ parseStartAction = do
     PostBuildHookType -> PostBuildHook <$> (one txt >>= parseDerivation)
     BuildWaitingType -> pure BuildWaiting
     FetchTreeType -> pure FetchTree
-  pure MkStartAction{id = MkId idField, text, activity, level}
+  pure MkStartAction{id = MkId idField, parent = MkId parentField, text, activity, level}

--- a/lib/NOM/State.hs
+++ b/lib/NOM/State.hs
@@ -262,6 +262,10 @@ data NOMState = MkNOMState
   , evaluationState :: EvalInfo
   , successTokens :: Int
   , buildsActivity :: Strict.Maybe ActivityId
+  , activityParents :: IntMap Int
+  -- ^ Maps activity ID to its parent activity ID
+  , activityRemoteStores :: IntMap (Host WithContext)
+  -- ^ Maps activity ID to the remote store it's associated with
   }
   deriving stock (Show, Eq, Ord)
 
@@ -291,6 +295,8 @@ initalStateFromBuildPlatform platform = do
       MkEvalInfo{count = 0, at = 0, lastFileName = Strict.Nothing}
       0
       Strict.Nothing
+      mempty
+      mempty
 
 instance Semigroup DependencySummary where
   (MkDependencySummary ls1 lm2 lm3 lm4 ls5 lm6 lm7 lm8 lm9) <> (MkDependencySummary rs1 rm2 rm3 rm4 rs5 rm6 rm7 rm8 rm9) = MkDependencySummary (ls1 <> rs1) (lm2 <> rm2) (lm3 <> rm3) (lm4 <> rm4) (ls5 <> rs5) (lm6 <> rm6) (lm7 <> rm7) (lm8 <> rm8) (lm9 <> rm9)

--- a/test/golden/fail/stderr.json
+++ b/test/golden/fail/stderr.json
@@ -1,12 +1,12 @@
 @nix {"action":"msg","level":4,"msg":"evaluating file '/disk/persist/maralorn/git/nix-output-monitor/test/golden/fail/default.nix'"}
 @nix {"action":"msg","level":4,"msg":"evaluating file '/disk/persist/maralorn/git/nix-output-monitor/test/golden/default.nix'"}
-@nix {"action":"start","id":2981506167341056,"level":6,"text":"querying info about missing paths","type":0}
-@nix {"action":"start","fields":["/nix/store/jzfs374r0px4h9zib7yrdnyzxd2hqjb8-build-fail","https://cache.nixos.org"],"id":2981506167341057,"level":4,"text":"querying info about '/nix/store/jzfs374r0px4h9zib7yrdnyzxd2hqjb8-build-fail' on 'https://cache.nixos.org'","type":109}
-@nix {"action":"start","fields":["/nix/store/7a09bnvr7kixk8rl8sakpb7kzb9v9alk-build-long","https://cache.nixos.org"],"id":2981506167341058,"level":4,"text":"querying info about '/nix/store/7a09bnvr7kixk8rl8sakpb7kzb9v9alk-build-long' on 'https://cache.nixos.org'","type":109}
-@nix {"action":"start","fields":["/nix/store/7kg0sxr83avn7p3f0q3rw0glnnvacajn-build-waiting","https://cache.nixos.org"],"id":2981506167341059,"level":4,"text":"querying info about '/nix/store/7kg0sxr83avn7p3f0q3rw0glnnvacajn-build-waiting' on 'https://cache.nixos.org'","type":109}
-@nix {"action":"start","fields":["https://cache.nixos.org/jzfs374r0px4h9zib7yrdnyzxd2hqjb8.narinfo"],"id":2981506167341060,"level":4,"text":"downloading 'https://cache.nixos.org/jzfs374r0px4h9zib7yrdnyzxd2hqjb8.narinfo'","type":101}
-@nix {"action":"start","fields":["https://cache.nixos.org/7a09bnvr7kixk8rl8sakpb7kzb9v9alk.narinfo"],"id":2981506167341061,"level":4,"text":"downloading 'https://cache.nixos.org/7a09bnvr7kixk8rl8sakpb7kzb9v9alk.narinfo'","type":101}
-@nix {"action":"start","fields":["https://cache.nixos.org/7kg0sxr83avn7p3f0q3rw0glnnvacajn.narinfo"],"id":2981506167341062,"level":4,"text":"downloading 'https://cache.nixos.org/7kg0sxr83avn7p3f0q3rw0glnnvacajn.narinfo'","type":101}
+@nix {"action":"start","parent":0,"id":2981506167341056,"level":6,"text":"querying info about missing paths","type":0}
+@nix {"action":"start","parent":0,"fields":["/nix/store/jzfs374r0px4h9zib7yrdnyzxd2hqjb8-build-fail","https://cache.nixos.org"],"id":2981506167341057,"level":4,"text":"querying info about '/nix/store/jzfs374r0px4h9zib7yrdnyzxd2hqjb8-build-fail' on 'https://cache.nixos.org'","type":109}
+@nix {"action":"start","parent":0,"fields":["/nix/store/7a09bnvr7kixk8rl8sakpb7kzb9v9alk-build-long","https://cache.nixos.org"],"id":2981506167341058,"level":4,"text":"querying info about '/nix/store/7a09bnvr7kixk8rl8sakpb7kzb9v9alk-build-long' on 'https://cache.nixos.org'","type":109}
+@nix {"action":"start","parent":0,"fields":["/nix/store/7kg0sxr83avn7p3f0q3rw0glnnvacajn-build-waiting","https://cache.nixos.org"],"id":2981506167341059,"level":4,"text":"querying info about '/nix/store/7kg0sxr83avn7p3f0q3rw0glnnvacajn-build-waiting' on 'https://cache.nixos.org'","type":109}
+@nix {"action":"start","parent":0,"fields":["https://cache.nixos.org/jzfs374r0px4h9zib7yrdnyzxd2hqjb8.narinfo"],"id":2981506167341060,"level":4,"text":"downloading 'https://cache.nixos.org/jzfs374r0px4h9zib7yrdnyzxd2hqjb8.narinfo'","type":101}
+@nix {"action":"start","parent":0,"fields":["https://cache.nixos.org/7a09bnvr7kixk8rl8sakpb7kzb9v9alk.narinfo"],"id":2981506167341061,"level":4,"text":"downloading 'https://cache.nixos.org/7a09bnvr7kixk8rl8sakpb7kzb9v9alk.narinfo'","type":101}
+@nix {"action":"start","parent":0,"fields":["https://cache.nixos.org/7kg0sxr83avn7p3f0q3rw0glnnvacajn.narinfo"],"id":2981506167341062,"level":4,"text":"downloading 'https://cache.nixos.org/7kg0sxr83avn7p3f0q3rw0glnnvacajn.narinfo'","type":101}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341060,"type":105}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341060,"type":105}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341060,"type":105}
@@ -53,8 +53,8 @@
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341062,"type":105}
 @nix {"action":"stop","id":2981506167341057}
 @nix {"action":"stop","id":2981506167341060}
-@nix {"action":"start","fields":["/nix/store/jzfs374r0px4h9zib7yrdnyzxd2hqjb8-build-fail","https://srid.cachix.org"],"id":2981506167341063,"level":4,"text":"querying info about '/nix/store/jzfs374r0px4h9zib7yrdnyzxd2hqjb8-build-fail' on 'https://srid.cachix.org'","type":109}
-@nix {"action":"start","fields":["https://srid.cachix.org/jzfs374r0px4h9zib7yrdnyzxd2hqjb8.narinfo"],"id":2981506167341064,"level":4,"text":"downloading 'https://srid.cachix.org/jzfs374r0px4h9zib7yrdnyzxd2hqjb8.narinfo'","type":101}
+@nix {"action":"start","parent":0,"fields":["/nix/store/jzfs374r0px4h9zib7yrdnyzxd2hqjb8-build-fail","https://srid.cachix.org"],"id":2981506167341063,"level":4,"text":"querying info about '/nix/store/jzfs374r0px4h9zib7yrdnyzxd2hqjb8-build-fail' on 'https://srid.cachix.org'","type":109}
+@nix {"action":"start","parent":0,"fields":["https://srid.cachix.org/jzfs374r0px4h9zib7yrdnyzxd2hqjb8.narinfo"],"id":2981506167341064,"level":4,"text":"downloading 'https://srid.cachix.org/jzfs374r0px4h9zib7yrdnyzxd2hqjb8.narinfo'","type":101}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341061,"type":105}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341061,"type":105}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341062,"type":105}
@@ -86,8 +86,8 @@
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341064,"type":105}
 @nix {"action":"stop","id":2981506167341058}
 @nix {"action":"stop","id":2981506167341061}
-@nix {"action":"start","fields":["/nix/store/7a09bnvr7kixk8rl8sakpb7kzb9v9alk-build-long","https://srid.cachix.org"],"id":2981506167341065,"level":4,"text":"querying info about '/nix/store/7a09bnvr7kixk8rl8sakpb7kzb9v9alk-build-long' on 'https://srid.cachix.org'","type":109}
-@nix {"action":"start","fields":["https://srid.cachix.org/7a09bnvr7kixk8rl8sakpb7kzb9v9alk.narinfo"],"id":2981506167341066,"level":4,"text":"downloading 'https://srid.cachix.org/7a09bnvr7kixk8rl8sakpb7kzb9v9alk.narinfo'","type":101}
+@nix {"action":"start","parent":0,"fields":["/nix/store/7a09bnvr7kixk8rl8sakpb7kzb9v9alk-build-long","https://srid.cachix.org"],"id":2981506167341065,"level":4,"text":"querying info about '/nix/store/7a09bnvr7kixk8rl8sakpb7kzb9v9alk-build-long' on 'https://srid.cachix.org'","type":109}
+@nix {"action":"start","parent":0,"fields":["https://srid.cachix.org/7a09bnvr7kixk8rl8sakpb7kzb9v9alk.narinfo"],"id":2981506167341066,"level":4,"text":"downloading 'https://srid.cachix.org/7a09bnvr7kixk8rl8sakpb7kzb9v9alk.narinfo'","type":101}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341062,"type":105}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341062,"type":105}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341064,"type":105}
@@ -124,8 +124,8 @@
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341066,"type":105}
 @nix {"action":"stop","id":2981506167341059}
 @nix {"action":"stop","id":2981506167341062}
-@nix {"action":"start","fields":["/nix/store/7kg0sxr83avn7p3f0q3rw0glnnvacajn-build-waiting","https://srid.cachix.org"],"id":2981506167341067,"level":4,"text":"querying info about '/nix/store/7kg0sxr83avn7p3f0q3rw0glnnvacajn-build-waiting' on 'https://srid.cachix.org'","type":109}
-@nix {"action":"start","fields":["https://srid.cachix.org/7kg0sxr83avn7p3f0q3rw0glnnvacajn.narinfo"],"id":2981506167341068,"level":4,"text":"downloading 'https://srid.cachix.org/7kg0sxr83avn7p3f0q3rw0glnnvacajn.narinfo'","type":101}
+@nix {"action":"start","parent":0,"fields":["/nix/store/7kg0sxr83avn7p3f0q3rw0glnnvacajn-build-waiting","https://srid.cachix.org"],"id":2981506167341067,"level":4,"text":"querying info about '/nix/store/7kg0sxr83avn7p3f0q3rw0glnnvacajn-build-waiting' on 'https://srid.cachix.org'","type":109}
+@nix {"action":"start","parent":0,"fields":["https://srid.cachix.org/7kg0sxr83avn7p3f0q3rw0glnnvacajn.narinfo"],"id":2981506167341068,"level":4,"text":"downloading 'https://srid.cachix.org/7kg0sxr83avn7p3f0q3rw0glnnvacajn.narinfo'","type":101}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341064,"type":105}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341064,"type":105}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341066,"type":105}
@@ -169,8 +169,8 @@
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341068,"type":105}
 @nix {"action":"stop","id":2981506167341065}
 @nix {"action":"stop","id":2981506167341066}
-@nix {"action":"start","fields":["/nix/store/7a09bnvr7kixk8rl8sakpb7kzb9v9alk-build-long","https://pre-commit-hooks.cachix.org"],"id":2981506167341069,"level":4,"text":"querying info about '/nix/store/7a09bnvr7kixk8rl8sakpb7kzb9v9alk-build-long' on 'https://pre-commit-hooks.cachix.org'","type":109}
-@nix {"action":"start","fields":["https://pre-commit-hooks.cachix.org/7a09bnvr7kixk8rl8sakpb7kzb9v9alk.narinfo"],"id":2981506167341070,"level":4,"text":"downloading 'https://pre-commit-hooks.cachix.org/7a09bnvr7kixk8rl8sakpb7kzb9v9alk.narinfo'","type":101}
+@nix {"action":"start","parent":0,"fields":["/nix/store/7a09bnvr7kixk8rl8sakpb7kzb9v9alk-build-long","https://pre-commit-hooks.cachix.org"],"id":2981506167341069,"level":4,"text":"querying info about '/nix/store/7a09bnvr7kixk8rl8sakpb7kzb9v9alk-build-long' on 'https://pre-commit-hooks.cachix.org'","type":109}
+@nix {"action":"start","parent":0,"fields":["https://pre-commit-hooks.cachix.org/7a09bnvr7kixk8rl8sakpb7kzb9v9alk.narinfo"],"id":2981506167341070,"level":4,"text":"downloading 'https://pre-commit-hooks.cachix.org/7a09bnvr7kixk8rl8sakpb7kzb9v9alk.narinfo'","type":101}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341064,"type":105}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341064,"type":105}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341068,"type":105}
@@ -196,8 +196,8 @@
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341070,"type":105}
 @nix {"action":"stop","id":2981506167341063}
 @nix {"action":"stop","id":2981506167341064}
-@nix {"action":"start","fields":["/nix/store/jzfs374r0px4h9zib7yrdnyzxd2hqjb8-build-fail","https://pre-commit-hooks.cachix.org"],"id":2981506167341071,"level":4,"text":"querying info about '/nix/store/jzfs374r0px4h9zib7yrdnyzxd2hqjb8-build-fail' on 'https://pre-commit-hooks.cachix.org'","type":109}
-@nix {"action":"start","fields":["https://pre-commit-hooks.cachix.org/jzfs374r0px4h9zib7yrdnyzxd2hqjb8.narinfo"],"id":2981506167341072,"level":4,"text":"downloading 'https://pre-commit-hooks.cachix.org/jzfs374r0px4h9zib7yrdnyzxd2hqjb8.narinfo'","type":101}
+@nix {"action":"start","parent":0,"fields":["/nix/store/jzfs374r0px4h9zib7yrdnyzxd2hqjb8-build-fail","https://pre-commit-hooks.cachix.org"],"id":2981506167341071,"level":4,"text":"querying info about '/nix/store/jzfs374r0px4h9zib7yrdnyzxd2hqjb8-build-fail' on 'https://pre-commit-hooks.cachix.org'","type":109}
+@nix {"action":"start","parent":0,"fields":["https://pre-commit-hooks.cachix.org/jzfs374r0px4h9zib7yrdnyzxd2hqjb8.narinfo"],"id":2981506167341072,"level":4,"text":"downloading 'https://pre-commit-hooks.cachix.org/jzfs374r0px4h9zib7yrdnyzxd2hqjb8.narinfo'","type":101}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341068,"type":105}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341068,"type":105}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341070,"type":105}
@@ -244,8 +244,8 @@
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341072,"type":105}
 @nix {"action":"stop","id":2981506167341067}
 @nix {"action":"stop","id":2981506167341068}
-@nix {"action":"start","fields":["/nix/store/7kg0sxr83avn7p3f0q3rw0glnnvacajn-build-waiting","https://pre-commit-hooks.cachix.org"],"id":2981506167341073,"level":4,"text":"querying info about '/nix/store/7kg0sxr83avn7p3f0q3rw0glnnvacajn-build-waiting' on 'https://pre-commit-hooks.cachix.org'","type":109}
-@nix {"action":"start","fields":["https://pre-commit-hooks.cachix.org/7kg0sxr83avn7p3f0q3rw0glnnvacajn.narinfo"],"id":2981506167341074,"level":4,"text":"downloading 'https://pre-commit-hooks.cachix.org/7kg0sxr83avn7p3f0q3rw0glnnvacajn.narinfo'","type":101}
+@nix {"action":"start","parent":0,"fields":["/nix/store/7kg0sxr83avn7p3f0q3rw0glnnvacajn-build-waiting","https://pre-commit-hooks.cachix.org"],"id":2981506167341073,"level":4,"text":"querying info about '/nix/store/7kg0sxr83avn7p3f0q3rw0glnnvacajn-build-waiting' on 'https://pre-commit-hooks.cachix.org'","type":109}
+@nix {"action":"start","parent":0,"fields":["https://pre-commit-hooks.cachix.org/7kg0sxr83avn7p3f0q3rw0glnnvacajn.narinfo"],"id":2981506167341074,"level":4,"text":"downloading 'https://pre-commit-hooks.cachix.org/7kg0sxr83avn7p3f0q3rw0glnnvacajn.narinfo'","type":101}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341070,"type":105}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341070,"type":105}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341072,"type":105}
@@ -271,8 +271,8 @@
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341074,"type":105}
 @nix {"action":"stop","id":2981506167341069}
 @nix {"action":"stop","id":2981506167341070}
-@nix {"action":"start","fields":["/nix/store/7a09bnvr7kixk8rl8sakpb7kzb9v9alk-build-long","https://mweinelt.cachix.org"],"id":2981506167341075,"level":4,"text":"querying info about '/nix/store/7a09bnvr7kixk8rl8sakpb7kzb9v9alk-build-long' on 'https://mweinelt.cachix.org'","type":109}
-@nix {"action":"start","fields":["https://mweinelt.cachix.org/7a09bnvr7kixk8rl8sakpb7kzb9v9alk.narinfo"],"id":2981506167341076,"level":4,"text":"downloading 'https://mweinelt.cachix.org/7a09bnvr7kixk8rl8sakpb7kzb9v9alk.narinfo'","type":101}
+@nix {"action":"start","parent":0,"fields":["/nix/store/7a09bnvr7kixk8rl8sakpb7kzb9v9alk-build-long","https://mweinelt.cachix.org"],"id":2981506167341075,"level":4,"text":"querying info about '/nix/store/7a09bnvr7kixk8rl8sakpb7kzb9v9alk-build-long' on 'https://mweinelt.cachix.org'","type":109}
+@nix {"action":"start","parent":0,"fields":["https://mweinelt.cachix.org/7a09bnvr7kixk8rl8sakpb7kzb9v9alk.narinfo"],"id":2981506167341076,"level":4,"text":"downloading 'https://mweinelt.cachix.org/7a09bnvr7kixk8rl8sakpb7kzb9v9alk.narinfo'","type":101}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341072,"type":105}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341072,"type":105}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341074,"type":105}
@@ -306,13 +306,13 @@
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341076,"type":105}
 @nix {"action":"stop","id":2981506167341071}
 @nix {"action":"stop","id":2981506167341072}
-@nix {"action":"start","fields":["/nix/store/jzfs374r0px4h9zib7yrdnyzxd2hqjb8-build-fail","https://mweinelt.cachix.org"],"id":2981506167341077,"level":4,"text":"querying info about '/nix/store/jzfs374r0px4h9zib7yrdnyzxd2hqjb8-build-fail' on 'https://mweinelt.cachix.org'","type":109}
-@nix {"action":"start","fields":["https://mweinelt.cachix.org/jzfs374r0px4h9zib7yrdnyzxd2hqjb8.narinfo"],"id":2981506167341078,"level":4,"text":"downloading 'https://mweinelt.cachix.org/jzfs374r0px4h9zib7yrdnyzxd2hqjb8.narinfo'","type":101}
+@nix {"action":"start","parent":0,"fields":["/nix/store/jzfs374r0px4h9zib7yrdnyzxd2hqjb8-build-fail","https://mweinelt.cachix.org"],"id":2981506167341077,"level":4,"text":"querying info about '/nix/store/jzfs374r0px4h9zib7yrdnyzxd2hqjb8-build-fail' on 'https://mweinelt.cachix.org'","type":109}
+@nix {"action":"start","parent":0,"fields":["https://mweinelt.cachix.org/jzfs374r0px4h9zib7yrdnyzxd2hqjb8.narinfo"],"id":2981506167341078,"level":4,"text":"downloading 'https://mweinelt.cachix.org/jzfs374r0px4h9zib7yrdnyzxd2hqjb8.narinfo'","type":101}
 @nix {"action":"stop","id":2981506167341073}
 @nix {"action":"stop","id":2981506167341074}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341076,"type":105}
-@nix {"action":"start","fields":["/nix/store/7kg0sxr83avn7p3f0q3rw0glnnvacajn-build-waiting","https://mweinelt.cachix.org"],"id":2981506167341079,"level":4,"text":"querying info about '/nix/store/7kg0sxr83avn7p3f0q3rw0glnnvacajn-build-waiting' on 'https://mweinelt.cachix.org'","type":109}
-@nix {"action":"start","fields":["https://mweinelt.cachix.org/7kg0sxr83avn7p3f0q3rw0glnnvacajn.narinfo"],"id":2981506167341080,"level":4,"text":"downloading 'https://mweinelt.cachix.org/7kg0sxr83avn7p3f0q3rw0glnnvacajn.narinfo'","type":101}
+@nix {"action":"start","parent":0,"fields":["/nix/store/7kg0sxr83avn7p3f0q3rw0glnnvacajn-build-waiting","https://mweinelt.cachix.org"],"id":2981506167341079,"level":4,"text":"querying info about '/nix/store/7kg0sxr83avn7p3f0q3rw0glnnvacajn-build-waiting' on 'https://mweinelt.cachix.org'","type":109}
+@nix {"action":"start","parent":0,"fields":["https://mweinelt.cachix.org/7kg0sxr83avn7p3f0q3rw0glnnvacajn.narinfo"],"id":2981506167341080,"level":4,"text":"downloading 'https://mweinelt.cachix.org/7kg0sxr83avn7p3f0q3rw0glnnvacajn.narinfo'","type":101}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341076,"type":105}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341076,"type":105}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341076,"type":105}
@@ -372,8 +372,8 @@
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341080,"type":105}
 @nix {"action":"stop","id":2981506167341075}
 @nix {"action":"stop","id":2981506167341076}
-@nix {"action":"start","fields":["/nix/store/7a09bnvr7kixk8rl8sakpb7kzb9v9alk-build-long","https://nixcache.reflex-frp.org"],"id":2981506167341081,"level":4,"text":"querying info about '/nix/store/7a09bnvr7kixk8rl8sakpb7kzb9v9alk-build-long' on 'https://nixcache.reflex-frp.org'","type":109}
-@nix {"action":"start","fields":["https://nixcache.reflex-frp.org/7a09bnvr7kixk8rl8sakpb7kzb9v9alk.narinfo"],"id":2981506167341082,"level":4,"text":"downloading 'https://nixcache.reflex-frp.org/7a09bnvr7kixk8rl8sakpb7kzb9v9alk.narinfo'","type":101}
+@nix {"action":"start","parent":0,"fields":["/nix/store/7a09bnvr7kixk8rl8sakpb7kzb9v9alk-build-long","https://nixcache.reflex-frp.org"],"id":2981506167341081,"level":4,"text":"querying info about '/nix/store/7a09bnvr7kixk8rl8sakpb7kzb9v9alk-build-long' on 'https://nixcache.reflex-frp.org'","type":109}
+@nix {"action":"start","parent":0,"fields":["https://nixcache.reflex-frp.org/7a09bnvr7kixk8rl8sakpb7kzb9v9alk.narinfo"],"id":2981506167341082,"level":4,"text":"downloading 'https://nixcache.reflex-frp.org/7a09bnvr7kixk8rl8sakpb7kzb9v9alk.narinfo'","type":101}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341078,"type":105}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341078,"type":105}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341080,"type":105}
@@ -489,8 +489,8 @@
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341082,"type":105}
 @nix {"action":"stop","id":2981506167341079}
 @nix {"action":"stop","id":2981506167341080}
-@nix {"action":"start","fields":["/nix/store/7kg0sxr83avn7p3f0q3rw0glnnvacajn-build-waiting","https://nixcache.reflex-frp.org"],"id":2981506167341083,"level":4,"text":"querying info about '/nix/store/7kg0sxr83avn7p3f0q3rw0glnnvacajn-build-waiting' on 'https://nixcache.reflex-frp.org'","type":109}
-@nix {"action":"start","fields":["https://nixcache.reflex-frp.org/7kg0sxr83avn7p3f0q3rw0glnnvacajn.narinfo"],"id":2981506167341084,"level":4,"text":"downloading 'https://nixcache.reflex-frp.org/7kg0sxr83avn7p3f0q3rw0glnnvacajn.narinfo'","type":101}
+@nix {"action":"start","parent":0,"fields":["/nix/store/7kg0sxr83avn7p3f0q3rw0glnnvacajn-build-waiting","https://nixcache.reflex-frp.org"],"id":2981506167341083,"level":4,"text":"querying info about '/nix/store/7kg0sxr83avn7p3f0q3rw0glnnvacajn-build-waiting' on 'https://nixcache.reflex-frp.org'","type":109}
+@nix {"action":"start","parent":0,"fields":["https://nixcache.reflex-frp.org/7kg0sxr83avn7p3f0q3rw0glnnvacajn.narinfo"],"id":2981506167341084,"level":4,"text":"downloading 'https://nixcache.reflex-frp.org/7kg0sxr83avn7p3f0q3rw0glnnvacajn.narinfo'","type":101}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341078,"type":105}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341078,"type":105}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341082,"type":105}
@@ -508,8 +508,8 @@
 @nix {"action":"stop","id":2981506167341077}
 @nix {"action":"stop","id":2981506167341078}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341082,"type":105}
-@nix {"action":"start","fields":["/nix/store/jzfs374r0px4h9zib7yrdnyzxd2hqjb8-build-fail","https://nixcache.reflex-frp.org"],"id":2981506167341085,"level":4,"text":"querying info about '/nix/store/jzfs374r0px4h9zib7yrdnyzxd2hqjb8-build-fail' on 'https://nixcache.reflex-frp.org'","type":109}
-@nix {"action":"start","fields":["https://nixcache.reflex-frp.org/jzfs374r0px4h9zib7yrdnyzxd2hqjb8.narinfo"],"id":2981506167341086,"level":4,"text":"downloading 'https://nixcache.reflex-frp.org/jzfs374r0px4h9zib7yrdnyzxd2hqjb8.narinfo'","type":101}
+@nix {"action":"start","parent":0,"fields":["/nix/store/jzfs374r0px4h9zib7yrdnyzxd2hqjb8-build-fail","https://nixcache.reflex-frp.org"],"id":2981506167341085,"level":4,"text":"querying info about '/nix/store/jzfs374r0px4h9zib7yrdnyzxd2hqjb8-build-fail' on 'https://nixcache.reflex-frp.org'","type":109}
+@nix {"action":"start","parent":0,"fields":["https://nixcache.reflex-frp.org/jzfs374r0px4h9zib7yrdnyzxd2hqjb8.narinfo"],"id":2981506167341086,"level":4,"text":"downloading 'https://nixcache.reflex-frp.org/jzfs374r0px4h9zib7yrdnyzxd2hqjb8.narinfo'","type":101}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341082,"type":105}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341082,"type":105}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341082,"type":105}
@@ -626,8 +626,8 @@
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341086,"type":105}
 @nix {"action":"stop","id":2981506167341081}
 @nix {"action":"stop","id":2981506167341082}
-@nix {"action":"start","fields":["/nix/store/7a09bnvr7kixk8rl8sakpb7kzb9v9alk-build-long","https://hydra.iohk.io"],"id":2981506167341087,"level":4,"text":"querying info about '/nix/store/7a09bnvr7kixk8rl8sakpb7kzb9v9alk-build-long' on 'https://hydra.iohk.io'","type":109}
-@nix {"action":"start","fields":["https://hydra.iohk.io/7a09bnvr7kixk8rl8sakpb7kzb9v9alk.narinfo"],"id":2981506167341088,"level":4,"text":"downloading 'https://hydra.iohk.io/7a09bnvr7kixk8rl8sakpb7kzb9v9alk.narinfo'","type":101}
+@nix {"action":"start","parent":0,"fields":["/nix/store/7a09bnvr7kixk8rl8sakpb7kzb9v9alk-build-long","https://hydra.iohk.io"],"id":2981506167341087,"level":4,"text":"querying info about '/nix/store/7a09bnvr7kixk8rl8sakpb7kzb9v9alk-build-long' on 'https://hydra.iohk.io'","type":109}
+@nix {"action":"start","parent":0,"fields":["https://hydra.iohk.io/7a09bnvr7kixk8rl8sakpb7kzb9v9alk.narinfo"],"id":2981506167341088,"level":4,"text":"downloading 'https://hydra.iohk.io/7a09bnvr7kixk8rl8sakpb7kzb9v9alk.narinfo'","type":101}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341084,"type":105}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341084,"type":105}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341086,"type":105}
@@ -685,8 +685,8 @@
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341088,"type":105}
 @nix {"action":"stop","id":2981506167341083}
 @nix {"action":"stop","id":2981506167341084}
-@nix {"action":"start","fields":["/nix/store/7kg0sxr83avn7p3f0q3rw0glnnvacajn-build-waiting","https://hydra.iohk.io"],"id":2981506167341089,"level":4,"text":"querying info about '/nix/store/7kg0sxr83avn7p3f0q3rw0glnnvacajn-build-waiting' on 'https://hydra.iohk.io'","type":109}
-@nix {"action":"start","fields":["https://hydra.iohk.io/7kg0sxr83avn7p3f0q3rw0glnnvacajn.narinfo"],"id":2981506167341090,"level":4,"text":"downloading 'https://hydra.iohk.io/7kg0sxr83avn7p3f0q3rw0glnnvacajn.narinfo'","type":101}
+@nix {"action":"start","parent":0,"fields":["/nix/store/7kg0sxr83avn7p3f0q3rw0glnnvacajn-build-waiting","https://hydra.iohk.io"],"id":2981506167341089,"level":4,"text":"querying info about '/nix/store/7kg0sxr83avn7p3f0q3rw0glnnvacajn-build-waiting' on 'https://hydra.iohk.io'","type":109}
+@nix {"action":"start","parent":0,"fields":["https://hydra.iohk.io/7kg0sxr83avn7p3f0q3rw0glnnvacajn.narinfo"],"id":2981506167341090,"level":4,"text":"downloading 'https://hydra.iohk.io/7kg0sxr83avn7p3f0q3rw0glnnvacajn.narinfo'","type":101}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341086,"type":105}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341086,"type":105}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341088,"type":105}
@@ -712,8 +712,8 @@
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341090,"type":105}
 @nix {"action":"stop","id":2981506167341085}
 @nix {"action":"stop","id":2981506167341086}
-@nix {"action":"start","fields":["/nix/store/jzfs374r0px4h9zib7yrdnyzxd2hqjb8-build-fail","https://hydra.iohk.io"],"id":2981506167341091,"level":4,"text":"querying info about '/nix/store/jzfs374r0px4h9zib7yrdnyzxd2hqjb8-build-fail' on 'https://hydra.iohk.io'","type":109}
-@nix {"action":"start","fields":["https://hydra.iohk.io/jzfs374r0px4h9zib7yrdnyzxd2hqjb8.narinfo"],"id":2981506167341092,"level":4,"text":"downloading 'https://hydra.iohk.io/jzfs374r0px4h9zib7yrdnyzxd2hqjb8.narinfo'","type":101}
+@nix {"action":"start","parent":0,"fields":["/nix/store/jzfs374r0px4h9zib7yrdnyzxd2hqjb8-build-fail","https://hydra.iohk.io"],"id":2981506167341091,"level":4,"text":"querying info about '/nix/store/jzfs374r0px4h9zib7yrdnyzxd2hqjb8-build-fail' on 'https://hydra.iohk.io'","type":109}
+@nix {"action":"start","parent":0,"fields":["https://hydra.iohk.io/jzfs374r0px4h9zib7yrdnyzxd2hqjb8.narinfo"],"id":2981506167341092,"level":4,"text":"downloading 'https://hydra.iohk.io/jzfs374r0px4h9zib7yrdnyzxd2hqjb8.narinfo'","type":101}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341088,"type":105}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341088,"type":105}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341090,"type":105}
@@ -884,9 +884,9 @@
 @nix {"action":"msg","level":3,"msg":"  /nix/store/1ia1hw6fqjmzhj2l5lv3nm5jnpcmc51j-build-fail.drv"}
 @nix {"action":"msg","level":3,"msg":"  /nix/store/408mzmx1vb33h86vli0s4n49sj0qmpgf-build-long.drv"}
 @nix {"action":"msg","level":3,"msg":"  /nix/store/nzamxil7jny36v62bg59h3hyv25fjz8r-build-waiting.drv"}
-@nix {"action":"start","id":2981506167341093,"level":0,"text":"","type":102}
-@nix {"action":"start","id":2981506167341094,"level":0,"text":"","type":104}
-@nix {"action":"start","id":2981506167341095,"level":0,"text":"","type":103}
+@nix {"action":"start","parent":0,"id":2981506167341093,"level":0,"text":"","type":102}
+@nix {"action":"start","parent":0,"id":2981506167341094,"level":0,"text":"","type":104}
+@nix {"action":"start","parent":0,"id":2981506167341095,"level":0,"text":"","type":103}
 @nix {"action":"result","fields":[0,1,0,0],"id":2981506167341094,"type":105}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341095,"type":105}
 @nix {"action":"result","fields":[101,0],"id":2981506167341093,"type":106}
@@ -899,14 +899,14 @@
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341095,"type":105}
 @nix {"action":"result","fields":[101,0],"id":2981506167341093,"type":106}
 @nix {"action":"result","fields":[100,0],"id":2981506167341093,"type":106}
-@nix {"action":"start","id":2981506167341096,"level":6,"text":"querying info about missing paths","type":0}
+@nix {"action":"start","parent":0,"id":2981506167341096,"level":6,"text":"querying info about missing paths","type":0}
 @nix {"action":"stop","id":2981506167341096}
-@nix {"action":"start","fields":["/nix/store/1ia1hw6fqjmzhj2l5lv3nm5jnpcmc51j-build-fail.drv","",1,1],"id":2981506167341097,"level":3,"text":"building '/nix/store/1ia1hw6fqjmzhj2l5lv3nm5jnpcmc51j-build-fail.drv'","type":105}
+@nix {"action":"start","parent":0,"fields":["/nix/store/1ia1hw6fqjmzhj2l5lv3nm5jnpcmc51j-build-fail.drv","",1,1],"id":2981506167341097,"level":3,"text":"building '/nix/store/1ia1hw6fqjmzhj2l5lv3nm5jnpcmc51j-build-fail.drv'","type":105}
 @nix {"action":"result","fields":[0,3,1,0],"id":2981506167341094,"type":105}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341095,"type":105}
 @nix {"action":"result","fields":[101,0],"id":2981506167341093,"type":106}
 @nix {"action":"result","fields":[100,0],"id":2981506167341093,"type":106}
-@nix {"action":"start","fields":["/nix/store/408mzmx1vb33h86vli0s4n49sj0qmpgf-build-long.drv","",1,1],"id":2981506167341098,"level":3,"text":"building '/nix/store/408mzmx1vb33h86vli0s4n49sj0qmpgf-build-long.drv'","type":105}
+@nix {"action":"start","parent":0,"fields":["/nix/store/408mzmx1vb33h86vli0s4n49sj0qmpgf-build-long.drv","",1,1],"id":2981506167341098,"level":3,"text":"building '/nix/store/408mzmx1vb33h86vli0s4n49sj0qmpgf-build-long.drv'","type":105}
 @nix {"action":"result","fields":[0,3,2,0],"id":2981506167341094,"type":105}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341095,"type":105}
 @nix {"action":"result","fields":[101,0],"id":2981506167341093,"type":106}

--- a/test/golden/standard/stderr.json
+++ b/test/golden/standard/stderr.json
@@ -1,14 +1,14 @@
 @nix {"action":"msg","level":4,"msg":"evaluating file '/disk/persist/maralorn/git/nix-output-monitor/test/golden/standard/default.nix'"}
 @nix {"action":"msg","level":4,"msg":"evaluating file '/disk/persist/maralorn/git/nix-output-monitor/test/golden/default.nix'"}
-@nix {"action":"start","id":2981506167341056,"level":6,"text":"querying info about missing paths","type":0}
-@nix {"action":"start","fields":["/nix/store/dzzc2s66k3i9fhwnmyd32axq65gjdyf9-build3","https://cache.nixos.org"],"id":2981506167341057,"level":4,"text":"querying info about '/nix/store/dzzc2s66k3i9fhwnmyd32axq65gjdyf9-build3' on 'https://cache.nixos.org'","type":109}
-@nix {"action":"start","fields":["/nix/store/pki9kcvm45p8whqa4nls5ipnlvgy4n9d-build2","https://cache.nixos.org"],"id":2981506167341058,"level":4,"text":"querying info about '/nix/store/pki9kcvm45p8whqa4nls5ipnlvgy4n9d-build2' on 'https://cache.nixos.org'","type":109}
-@nix {"action":"start","fields":["/nix/store/0kzm0jjrfrx167f7h2qpc72naqgijjq6-build1","https://cache.nixos.org"],"id":2981506167341059,"level":4,"text":"querying info about '/nix/store/0kzm0jjrfrx167f7h2qpc72naqgijjq6-build1' on 'https://cache.nixos.org'","type":109}
-@nix {"action":"start","fields":["/nix/store/6wdndqhg7vzhn798icnhfsj5z0qxsxj5-build4","https://cache.nixos.org"],"id":2981506167341060,"level":4,"text":"querying info about '/nix/store/6wdndqhg7vzhn798icnhfsj5z0qxsxj5-build4' on 'https://cache.nixos.org'","type":109}
-@nix {"action":"start","fields":["https://cache.nixos.org/dzzc2s66k3i9fhwnmyd32axq65gjdyf9.narinfo"],"id":2981506167341061,"level":4,"text":"downloading 'https://cache.nixos.org/dzzc2s66k3i9fhwnmyd32axq65gjdyf9.narinfo'","type":101}
-@nix {"action":"start","fields":["https://cache.nixos.org/0kzm0jjrfrx167f7h2qpc72naqgijjq6.narinfo"],"id":2981506167341063,"level":4,"text":"downloading 'https://cache.nixos.org/0kzm0jjrfrx167f7h2qpc72naqgijjq6.narinfo'","type":101}
-@nix {"action":"start","fields":["https://cache.nixos.org/pki9kcvm45p8whqa4nls5ipnlvgy4n9d.narinfo"],"id":2981506167341062,"level":4,"text":"downloading 'https://cache.nixos.org/pki9kcvm45p8whqa4nls5ipnlvgy4n9d.narinfo'","type":101}
-@nix {"action":"start","fields":["https://cache.nixos.org/6wdndqhg7vzhn798icnhfsj5z0qxsxj5.narinfo"],"id":2981506167341064,"level":4,"text":"downloading 'https://cache.nixos.org/6wdndqhg7vzhn798icnhfsj5z0qxsxj5.narinfo'","type":101}
+@nix {"action":"start","parent":0,"id":2981506167341056,"level":6,"text":"querying info about missing paths","type":0}
+@nix {"action":"start","parent":0,"fields":["/nix/store/dzzc2s66k3i9fhwnmyd32axq65gjdyf9-build3","https://cache.nixos.org"],"id":2981506167341057,"level":4,"text":"querying info about '/nix/store/dzzc2s66k3i9fhwnmyd32axq65gjdyf9-build3' on 'https://cache.nixos.org'","type":109}
+@nix {"action":"start","parent":0,"fields":["/nix/store/pki9kcvm45p8whqa4nls5ipnlvgy4n9d-build2","https://cache.nixos.org"],"id":2981506167341058,"level":4,"text":"querying info about '/nix/store/pki9kcvm45p8whqa4nls5ipnlvgy4n9d-build2' on 'https://cache.nixos.org'","type":109}
+@nix {"action":"start","parent":0,"fields":["/nix/store/0kzm0jjrfrx167f7h2qpc72naqgijjq6-build1","https://cache.nixos.org"],"id":2981506167341059,"level":4,"text":"querying info about '/nix/store/0kzm0jjrfrx167f7h2qpc72naqgijjq6-build1' on 'https://cache.nixos.org'","type":109}
+@nix {"action":"start","parent":0,"fields":["/nix/store/6wdndqhg7vzhn798icnhfsj5z0qxsxj5-build4","https://cache.nixos.org"],"id":2981506167341060,"level":4,"text":"querying info about '/nix/store/6wdndqhg7vzhn798icnhfsj5z0qxsxj5-build4' on 'https://cache.nixos.org'","type":109}
+@nix {"action":"start","parent":0,"fields":["https://cache.nixos.org/dzzc2s66k3i9fhwnmyd32axq65gjdyf9.narinfo"],"id":2981506167341061,"level":4,"text":"downloading 'https://cache.nixos.org/dzzc2s66k3i9fhwnmyd32axq65gjdyf9.narinfo'","type":101}
+@nix {"action":"start","parent":0,"fields":["https://cache.nixos.org/0kzm0jjrfrx167f7h2qpc72naqgijjq6.narinfo"],"id":2981506167341063,"level":4,"text":"downloading 'https://cache.nixos.org/0kzm0jjrfrx167f7h2qpc72naqgijjq6.narinfo'","type":101}
+@nix {"action":"start","parent":0,"fields":["https://cache.nixos.org/pki9kcvm45p8whqa4nls5ipnlvgy4n9d.narinfo"],"id":2981506167341062,"level":4,"text":"downloading 'https://cache.nixos.org/pki9kcvm45p8whqa4nls5ipnlvgy4n9d.narinfo'","type":101}
+@nix {"action":"start","parent":0,"fields":["https://cache.nixos.org/6wdndqhg7vzhn798icnhfsj5z0qxsxj5.narinfo"],"id":2981506167341064,"level":4,"text":"downloading 'https://cache.nixos.org/6wdndqhg7vzhn798icnhfsj5z0qxsxj5.narinfo'","type":101}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341061,"type":105}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341061,"type":105}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341061,"type":105}
@@ -65,8 +65,8 @@
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341064,"type":105}
 @nix {"action":"stop","id":2981506167341058}
 @nix {"action":"stop","id":2981506167341062}
-@nix {"action":"start","fields":["/nix/store/pki9kcvm45p8whqa4nls5ipnlvgy4n9d-build2","https://srid.cachix.org"],"id":2981506167341065,"level":4,"text":"querying info about '/nix/store/pki9kcvm45p8whqa4nls5ipnlvgy4n9d-build2' on 'https://srid.cachix.org'","type":109}
-@nix {"action":"start","fields":["https://srid.cachix.org/pki9kcvm45p8whqa4nls5ipnlvgy4n9d.narinfo"],"id":2981506167341066,"level":4,"text":"downloading 'https://srid.cachix.org/pki9kcvm45p8whqa4nls5ipnlvgy4n9d.narinfo'","type":101}
+@nix {"action":"start","parent":0,"fields":["/nix/store/pki9kcvm45p8whqa4nls5ipnlvgy4n9d-build2","https://srid.cachix.org"],"id":2981506167341065,"level":4,"text":"querying info about '/nix/store/pki9kcvm45p8whqa4nls5ipnlvgy4n9d-build2' on 'https://srid.cachix.org'","type":109}
+@nix {"action":"start","parent":0,"fields":["https://srid.cachix.org/pki9kcvm45p8whqa4nls5ipnlvgy4n9d.narinfo"],"id":2981506167341066,"level":4,"text":"downloading 'https://srid.cachix.org/pki9kcvm45p8whqa4nls5ipnlvgy4n9d.narinfo'","type":101}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341061,"type":105}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341061,"type":105}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341063,"type":105}
@@ -114,8 +114,8 @@
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341066,"type":105}
 @nix {"action":"stop","id":2981506167341060}
 @nix {"action":"stop","id":2981506167341064}
-@nix {"action":"start","fields":["/nix/store/6wdndqhg7vzhn798icnhfsj5z0qxsxj5-build4","https://srid.cachix.org"],"id":2981506167341067,"level":4,"text":"querying info about '/nix/store/6wdndqhg7vzhn798icnhfsj5z0qxsxj5-build4' on 'https://srid.cachix.org'","type":109}
-@nix {"action":"start","fields":["https://srid.cachix.org/6wdndqhg7vzhn798icnhfsj5z0qxsxj5.narinfo"],"id":2981506167341068,"level":4,"text":"downloading 'https://srid.cachix.org/6wdndqhg7vzhn798icnhfsj5z0qxsxj5.narinfo'","type":101}
+@nix {"action":"start","parent":0,"fields":["/nix/store/6wdndqhg7vzhn798icnhfsj5z0qxsxj5-build4","https://srid.cachix.org"],"id":2981506167341067,"level":4,"text":"querying info about '/nix/store/6wdndqhg7vzhn798icnhfsj5z0qxsxj5-build4' on 'https://srid.cachix.org'","type":109}
+@nix {"action":"start","parent":0,"fields":["https://srid.cachix.org/6wdndqhg7vzhn798icnhfsj5z0qxsxj5.narinfo"],"id":2981506167341068,"level":4,"text":"downloading 'https://srid.cachix.org/6wdndqhg7vzhn798icnhfsj5z0qxsxj5.narinfo'","type":101}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341061,"type":105}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341061,"type":105}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341063,"type":105}
@@ -139,8 +139,8 @@
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341063,"type":105}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341063,"type":105}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341066,"type":105}
-@nix {"action":"start","fields":["/nix/store/dzzc2s66k3i9fhwnmyd32axq65gjdyf9-build3","https://srid.cachix.org"],"id":2981506167341069,"level":4,"text":"querying info about '/nix/store/dzzc2s66k3i9fhwnmyd32axq65gjdyf9-build3' on 'https://srid.cachix.org'","type":109}
-@nix {"action":"start","fields":["https://srid.cachix.org/dzzc2s66k3i9fhwnmyd32axq65gjdyf9.narinfo"],"id":2981506167341070,"level":4,"text":"downloading 'https://srid.cachix.org/dzzc2s66k3i9fhwnmyd32axq65gjdyf9.narinfo'","type":101}
+@nix {"action":"start","parent":0,"fields":["/nix/store/dzzc2s66k3i9fhwnmyd32axq65gjdyf9-build3","https://srid.cachix.org"],"id":2981506167341069,"level":4,"text":"querying info about '/nix/store/dzzc2s66k3i9fhwnmyd32axq65gjdyf9-build3' on 'https://srid.cachix.org'","type":109}
+@nix {"action":"start","parent":0,"fields":["https://srid.cachix.org/dzzc2s66k3i9fhwnmyd32axq65gjdyf9.narinfo"],"id":2981506167341070,"level":4,"text":"downloading 'https://srid.cachix.org/dzzc2s66k3i9fhwnmyd32axq65gjdyf9.narinfo'","type":101}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341063,"type":105}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341063,"type":105}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341066,"type":105}
@@ -152,8 +152,8 @@
 @nix {"action":"stop","id":2981506167341059}
 @nix {"action":"stop","id":2981506167341063}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341066,"type":105}
-@nix {"action":"start","fields":["/nix/store/0kzm0jjrfrx167f7h2qpc72naqgijjq6-build1","https://srid.cachix.org"],"id":2981506167341071,"level":4,"text":"querying info about '/nix/store/0kzm0jjrfrx167f7h2qpc72naqgijjq6-build1' on 'https://srid.cachix.org'","type":109}
-@nix {"action":"start","fields":["https://srid.cachix.org/0kzm0jjrfrx167f7h2qpc72naqgijjq6.narinfo"],"id":2981506167341072,"level":4,"text":"downloading 'https://srid.cachix.org/0kzm0jjrfrx167f7h2qpc72naqgijjq6.narinfo'","type":101}
+@nix {"action":"start","parent":0,"fields":["/nix/store/0kzm0jjrfrx167f7h2qpc72naqgijjq6-build1","https://srid.cachix.org"],"id":2981506167341071,"level":4,"text":"querying info about '/nix/store/0kzm0jjrfrx167f7h2qpc72naqgijjq6-build1' on 'https://srid.cachix.org'","type":109}
+@nix {"action":"start","parent":0,"fields":["https://srid.cachix.org/0kzm0jjrfrx167f7h2qpc72naqgijjq6.narinfo"],"id":2981506167341072,"level":4,"text":"downloading 'https://srid.cachix.org/0kzm0jjrfrx167f7h2qpc72naqgijjq6.narinfo'","type":101}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341066,"type":105}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341066,"type":105}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341066,"type":105}
@@ -230,8 +230,8 @@
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341072,"type":105}
 @nix {"action":"stop","id":2981506167341065}
 @nix {"action":"stop","id":2981506167341066}
-@nix {"action":"start","fields":["/nix/store/pki9kcvm45p8whqa4nls5ipnlvgy4n9d-build2","https://pre-commit-hooks.cachix.org"],"id":2981506167341073,"level":4,"text":"querying info about '/nix/store/pki9kcvm45p8whqa4nls5ipnlvgy4n9d-build2' on 'https://pre-commit-hooks.cachix.org'","type":109}
-@nix {"action":"start","fields":["https://pre-commit-hooks.cachix.org/pki9kcvm45p8whqa4nls5ipnlvgy4n9d.narinfo"],"id":2981506167341074,"level":4,"text":"downloading 'https://pre-commit-hooks.cachix.org/pki9kcvm45p8whqa4nls5ipnlvgy4n9d.narinfo'","type":101}
+@nix {"action":"start","parent":0,"fields":["/nix/store/pki9kcvm45p8whqa4nls5ipnlvgy4n9d-build2","https://pre-commit-hooks.cachix.org"],"id":2981506167341073,"level":4,"text":"querying info about '/nix/store/pki9kcvm45p8whqa4nls5ipnlvgy4n9d-build2' on 'https://pre-commit-hooks.cachix.org'","type":109}
+@nix {"action":"start","parent":0,"fields":["https://pre-commit-hooks.cachix.org/pki9kcvm45p8whqa4nls5ipnlvgy4n9d.narinfo"],"id":2981506167341074,"level":4,"text":"downloading 'https://pre-commit-hooks.cachix.org/pki9kcvm45p8whqa4nls5ipnlvgy4n9d.narinfo'","type":101}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341068,"type":105}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341068,"type":105}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341070,"type":105}
@@ -265,8 +265,8 @@
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341074,"type":105}
 @nix {"action":"stop","id":2981506167341067}
 @nix {"action":"stop","id":2981506167341068}
-@nix {"action":"start","fields":["/nix/store/6wdndqhg7vzhn798icnhfsj5z0qxsxj5-build4","https://pre-commit-hooks.cachix.org"],"id":2981506167341075,"level":4,"text":"querying info about '/nix/store/6wdndqhg7vzhn798icnhfsj5z0qxsxj5-build4' on 'https://pre-commit-hooks.cachix.org'","type":109}
-@nix {"action":"start","fields":["https://pre-commit-hooks.cachix.org/6wdndqhg7vzhn798icnhfsj5z0qxsxj5.narinfo"],"id":2981506167341076,"level":4,"text":"downloading 'https://pre-commit-hooks.cachix.org/6wdndqhg7vzhn798icnhfsj5z0qxsxj5.narinfo'","type":101}
+@nix {"action":"start","parent":0,"fields":["/nix/store/6wdndqhg7vzhn798icnhfsj5z0qxsxj5-build4","https://pre-commit-hooks.cachix.org"],"id":2981506167341075,"level":4,"text":"querying info about '/nix/store/6wdndqhg7vzhn798icnhfsj5z0qxsxj5-build4' on 'https://pre-commit-hooks.cachix.org'","type":109}
+@nix {"action":"start","parent":0,"fields":["https://pre-commit-hooks.cachix.org/6wdndqhg7vzhn798icnhfsj5z0qxsxj5.narinfo"],"id":2981506167341076,"level":4,"text":"downloading 'https://pre-commit-hooks.cachix.org/6wdndqhg7vzhn798icnhfsj5z0qxsxj5.narinfo'","type":101}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341070,"type":105}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341070,"type":105}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341072,"type":105}
@@ -290,8 +290,8 @@
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341070,"type":105}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341070,"type":105}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341074,"type":105}
-@nix {"action":"start","fields":["/nix/store/0kzm0jjrfrx167f7h2qpc72naqgijjq6-build1","https://pre-commit-hooks.cachix.org"],"id":2981506167341077,"level":4,"text":"querying info about '/nix/store/0kzm0jjrfrx167f7h2qpc72naqgijjq6-build1' on 'https://pre-commit-hooks.cachix.org'","type":109}
-@nix {"action":"start","fields":["https://pre-commit-hooks.cachix.org/0kzm0jjrfrx167f7h2qpc72naqgijjq6.narinfo"],"id":2981506167341078,"level":4,"text":"downloading 'https://pre-commit-hooks.cachix.org/0kzm0jjrfrx167f7h2qpc72naqgijjq6.narinfo'","type":101}
+@nix {"action":"start","parent":0,"fields":["/nix/store/0kzm0jjrfrx167f7h2qpc72naqgijjq6-build1","https://pre-commit-hooks.cachix.org"],"id":2981506167341077,"level":4,"text":"querying info about '/nix/store/0kzm0jjrfrx167f7h2qpc72naqgijjq6-build1' on 'https://pre-commit-hooks.cachix.org'","type":109}
+@nix {"action":"start","parent":0,"fields":["https://pre-commit-hooks.cachix.org/0kzm0jjrfrx167f7h2qpc72naqgijjq6.narinfo"],"id":2981506167341078,"level":4,"text":"downloading 'https://pre-commit-hooks.cachix.org/0kzm0jjrfrx167f7h2qpc72naqgijjq6.narinfo'","type":101}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341070,"type":105}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341070,"type":105}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341074,"type":105}
@@ -335,8 +335,8 @@
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341078,"type":105}
 @nix {"action":"stop","id":2981506167341069}
 @nix {"action":"stop","id":2981506167341070}
-@nix {"action":"start","fields":["/nix/store/dzzc2s66k3i9fhwnmyd32axq65gjdyf9-build3","https://pre-commit-hooks.cachix.org"],"id":2981506167341079,"level":4,"text":"querying info about '/nix/store/dzzc2s66k3i9fhwnmyd32axq65gjdyf9-build3' on 'https://pre-commit-hooks.cachix.org'","type":109}
-@nix {"action":"start","fields":["https://pre-commit-hooks.cachix.org/dzzc2s66k3i9fhwnmyd32axq65gjdyf9.narinfo"],"id":2981506167341080,"level":4,"text":"downloading 'https://pre-commit-hooks.cachix.org/dzzc2s66k3i9fhwnmyd32axq65gjdyf9.narinfo'","type":101}
+@nix {"action":"start","parent":0,"fields":["/nix/store/dzzc2s66k3i9fhwnmyd32axq65gjdyf9-build3","https://pre-commit-hooks.cachix.org"],"id":2981506167341079,"level":4,"text":"querying info about '/nix/store/dzzc2s66k3i9fhwnmyd32axq65gjdyf9-build3' on 'https://pre-commit-hooks.cachix.org'","type":109}
+@nix {"action":"start","parent":0,"fields":["https://pre-commit-hooks.cachix.org/dzzc2s66k3i9fhwnmyd32axq65gjdyf9.narinfo"],"id":2981506167341080,"level":4,"text":"downloading 'https://pre-commit-hooks.cachix.org/dzzc2s66k3i9fhwnmyd32axq65gjdyf9.narinfo'","type":101}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341074,"type":105}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341074,"type":105}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341076,"type":105}
@@ -394,8 +394,8 @@
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341080,"type":105}
 @nix {"action":"stop","id":2981506167341073}
 @nix {"action":"stop","id":2981506167341074}
-@nix {"action":"start","fields":["/nix/store/pki9kcvm45p8whqa4nls5ipnlvgy4n9d-build2","https://mweinelt.cachix.org"],"id":2981506167341081,"level":4,"text":"querying info about '/nix/store/pki9kcvm45p8whqa4nls5ipnlvgy4n9d-build2' on 'https://mweinelt.cachix.org'","type":109}
-@nix {"action":"start","fields":["https://mweinelt.cachix.org/pki9kcvm45p8whqa4nls5ipnlvgy4n9d.narinfo"],"id":2981506167341082,"level":4,"text":"downloading 'https://mweinelt.cachix.org/pki9kcvm45p8whqa4nls5ipnlvgy4n9d.narinfo'","type":101}
+@nix {"action":"start","parent":0,"fields":["/nix/store/pki9kcvm45p8whqa4nls5ipnlvgy4n9d-build2","https://mweinelt.cachix.org"],"id":2981506167341081,"level":4,"text":"querying info about '/nix/store/pki9kcvm45p8whqa4nls5ipnlvgy4n9d-build2' on 'https://mweinelt.cachix.org'","type":109}
+@nix {"action":"start","parent":0,"fields":["https://mweinelt.cachix.org/pki9kcvm45p8whqa4nls5ipnlvgy4n9d.narinfo"],"id":2981506167341082,"level":4,"text":"downloading 'https://mweinelt.cachix.org/pki9kcvm45p8whqa4nls5ipnlvgy4n9d.narinfo'","type":101}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341076,"type":105}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341076,"type":105}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341078,"type":105}
@@ -429,8 +429,8 @@
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341082,"type":105}
 @nix {"action":"stop","id":2981506167341079}
 @nix {"action":"stop","id":2981506167341080}
-@nix {"action":"start","fields":["/nix/store/dzzc2s66k3i9fhwnmyd32axq65gjdyf9-build3","https://mweinelt.cachix.org"],"id":2981506167341083,"level":4,"text":"querying info about '/nix/store/dzzc2s66k3i9fhwnmyd32axq65gjdyf9-build3' on 'https://mweinelt.cachix.org'","type":109}
-@nix {"action":"start","fields":["https://mweinelt.cachix.org/dzzc2s66k3i9fhwnmyd32axq65gjdyf9.narinfo"],"id":2981506167341084,"level":4,"text":"downloading 'https://mweinelt.cachix.org/dzzc2s66k3i9fhwnmyd32axq65gjdyf9.narinfo'","type":101}
+@nix {"action":"start","parent":0,"fields":["/nix/store/dzzc2s66k3i9fhwnmyd32axq65gjdyf9-build3","https://mweinelt.cachix.org"],"id":2981506167341083,"level":4,"text":"querying info about '/nix/store/dzzc2s66k3i9fhwnmyd32axq65gjdyf9-build3' on 'https://mweinelt.cachix.org'","type":109}
+@nix {"action":"start","parent":0,"fields":["https://mweinelt.cachix.org/dzzc2s66k3i9fhwnmyd32axq65gjdyf9.narinfo"],"id":2981506167341084,"level":4,"text":"downloading 'https://mweinelt.cachix.org/dzzc2s66k3i9fhwnmyd32axq65gjdyf9.narinfo'","type":101}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341076,"type":105}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341076,"type":105}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341078,"type":105}
@@ -453,13 +453,13 @@
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341082,"type":105}
 @nix {"action":"stop","id":2981506167341075}
 @nix {"action":"stop","id":2981506167341076}
-@nix {"action":"start","fields":["/nix/store/6wdndqhg7vzhn798icnhfsj5z0qxsxj5-build4","https://mweinelt.cachix.org"],"id":2981506167341085,"level":4,"text":"querying info about '/nix/store/6wdndqhg7vzhn798icnhfsj5z0qxsxj5-build4' on 'https://mweinelt.cachix.org'","type":109}
-@nix {"action":"start","fields":["https://mweinelt.cachix.org/6wdndqhg7vzhn798icnhfsj5z0qxsxj5.narinfo"],"id":2981506167341086,"level":4,"text":"downloading 'https://mweinelt.cachix.org/6wdndqhg7vzhn798icnhfsj5z0qxsxj5.narinfo'","type":101}
+@nix {"action":"start","parent":0,"fields":["/nix/store/6wdndqhg7vzhn798icnhfsj5z0qxsxj5-build4","https://mweinelt.cachix.org"],"id":2981506167341085,"level":4,"text":"querying info about '/nix/store/6wdndqhg7vzhn798icnhfsj5z0qxsxj5-build4' on 'https://mweinelt.cachix.org'","type":109}
+@nix {"action":"start","parent":0,"fields":["https://mweinelt.cachix.org/6wdndqhg7vzhn798icnhfsj5z0qxsxj5.narinfo"],"id":2981506167341086,"level":4,"text":"downloading 'https://mweinelt.cachix.org/6wdndqhg7vzhn798icnhfsj5z0qxsxj5.narinfo'","type":101}
 @nix {"action":"stop","id":2981506167341077}
 @nix {"action":"stop","id":2981506167341078}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341082,"type":105}
-@nix {"action":"start","fields":["/nix/store/0kzm0jjrfrx167f7h2qpc72naqgijjq6-build1","https://mweinelt.cachix.org"],"id":2981506167341087,"level":4,"text":"querying info about '/nix/store/0kzm0jjrfrx167f7h2qpc72naqgijjq6-build1' on 'https://mweinelt.cachix.org'","type":109}
-@nix {"action":"start","fields":["https://mweinelt.cachix.org/0kzm0jjrfrx167f7h2qpc72naqgijjq6.narinfo"],"id":2981506167341088,"level":4,"text":"downloading 'https://mweinelt.cachix.org/0kzm0jjrfrx167f7h2qpc72naqgijjq6.narinfo'","type":101}
+@nix {"action":"start","parent":0,"fields":["/nix/store/0kzm0jjrfrx167f7h2qpc72naqgijjq6-build1","https://mweinelt.cachix.org"],"id":2981506167341087,"level":4,"text":"querying info about '/nix/store/0kzm0jjrfrx167f7h2qpc72naqgijjq6-build1' on 'https://mweinelt.cachix.org'","type":109}
+@nix {"action":"start","parent":0,"fields":["https://mweinelt.cachix.org/0kzm0jjrfrx167f7h2qpc72naqgijjq6.narinfo"],"id":2981506167341088,"level":4,"text":"downloading 'https://mweinelt.cachix.org/0kzm0jjrfrx167f7h2qpc72naqgijjq6.narinfo'","type":101}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341082,"type":105}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341082,"type":105}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341082,"type":105}
@@ -536,8 +536,8 @@
 @nix {"action":"result","fields":[15,0,0,0],"id":2981506167341088,"type":105}
 @nix {"action":"stop","id":2981506167341087}
 @nix {"action":"stop","id":2981506167341088}
-@nix {"action":"start","fields":["/nix/store/0kzm0jjrfrx167f7h2qpc72naqgijjq6-build1","https://nixcache.reflex-frp.org"],"id":2981506167341089,"level":4,"text":"querying info about '/nix/store/0kzm0jjrfrx167f7h2qpc72naqgijjq6-build1' on 'https://nixcache.reflex-frp.org'","type":109}
-@nix {"action":"start","fields":["https://nixcache.reflex-frp.org/0kzm0jjrfrx167f7h2qpc72naqgijjq6.narinfo"],"id":2981506167341090,"level":4,"text":"downloading 'https://nixcache.reflex-frp.org/0kzm0jjrfrx167f7h2qpc72naqgijjq6.narinfo'","type":101}
+@nix {"action":"start","parent":0,"fields":["/nix/store/0kzm0jjrfrx167f7h2qpc72naqgijjq6-build1","https://nixcache.reflex-frp.org"],"id":2981506167341089,"level":4,"text":"querying info about '/nix/store/0kzm0jjrfrx167f7h2qpc72naqgijjq6-build1' on 'https://nixcache.reflex-frp.org'","type":109}
+@nix {"action":"start","parent":0,"fields":["https://nixcache.reflex-frp.org/0kzm0jjrfrx167f7h2qpc72naqgijjq6.narinfo"],"id":2981506167341090,"level":4,"text":"downloading 'https://nixcache.reflex-frp.org/0kzm0jjrfrx167f7h2qpc72naqgijjq6.narinfo'","type":101}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341082,"type":105}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341082,"type":105}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341084,"type":105}
@@ -644,8 +644,8 @@
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341090,"type":105}
 @nix {"action":"stop","id":2981506167341083}
 @nix {"action":"stop","id":2981506167341084}
-@nix {"action":"start","fields":["/nix/store/dzzc2s66k3i9fhwnmyd32axq65gjdyf9-build3","https://nixcache.reflex-frp.org"],"id":2981506167341091,"level":4,"text":"querying info about '/nix/store/dzzc2s66k3i9fhwnmyd32axq65gjdyf9-build3' on 'https://nixcache.reflex-frp.org'","type":109}
-@nix {"action":"start","fields":["https://nixcache.reflex-frp.org/dzzc2s66k3i9fhwnmyd32axq65gjdyf9.narinfo"],"id":2981506167341092,"level":4,"text":"downloading 'https://nixcache.reflex-frp.org/dzzc2s66k3i9fhwnmyd32axq65gjdyf9.narinfo'","type":101}
+@nix {"action":"start","parent":0,"fields":["/nix/store/dzzc2s66k3i9fhwnmyd32axq65gjdyf9-build3","https://nixcache.reflex-frp.org"],"id":2981506167341091,"level":4,"text":"querying info about '/nix/store/dzzc2s66k3i9fhwnmyd32axq65gjdyf9-build3' on 'https://nixcache.reflex-frp.org'","type":109}
+@nix {"action":"start","parent":0,"fields":["https://nixcache.reflex-frp.org/dzzc2s66k3i9fhwnmyd32axq65gjdyf9.narinfo"],"id":2981506167341092,"level":4,"text":"downloading 'https://nixcache.reflex-frp.org/dzzc2s66k3i9fhwnmyd32axq65gjdyf9.narinfo'","type":101}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341082,"type":105}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341082,"type":105}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341086,"type":105}
@@ -722,8 +722,8 @@
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341092,"type":105}
 @nix {"action":"stop","id":2981506167341081}
 @nix {"action":"stop","id":2981506167341082}
-@nix {"action":"start","fields":["/nix/store/pki9kcvm45p8whqa4nls5ipnlvgy4n9d-build2","https://nixcache.reflex-frp.org"],"id":2981506167341093,"level":4,"text":"querying info about '/nix/store/pki9kcvm45p8whqa4nls5ipnlvgy4n9d-build2' on 'https://nixcache.reflex-frp.org'","type":109}
-@nix {"action":"start","fields":["https://nixcache.reflex-frp.org/pki9kcvm45p8whqa4nls5ipnlvgy4n9d.narinfo"],"id":2981506167341094,"level":4,"text":"downloading 'https://nixcache.reflex-frp.org/pki9kcvm45p8whqa4nls5ipnlvgy4n9d.narinfo'","type":101}
+@nix {"action":"start","parent":0,"fields":["/nix/store/pki9kcvm45p8whqa4nls5ipnlvgy4n9d-build2","https://nixcache.reflex-frp.org"],"id":2981506167341093,"level":4,"text":"querying info about '/nix/store/pki9kcvm45p8whqa4nls5ipnlvgy4n9d-build2' on 'https://nixcache.reflex-frp.org'","type":109}
+@nix {"action":"start","parent":0,"fields":["https://nixcache.reflex-frp.org/pki9kcvm45p8whqa4nls5ipnlvgy4n9d.narinfo"],"id":2981506167341094,"level":4,"text":"downloading 'https://nixcache.reflex-frp.org/pki9kcvm45p8whqa4nls5ipnlvgy4n9d.narinfo'","type":101}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341086,"type":105}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341086,"type":105}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341090,"type":105}
@@ -793,8 +793,8 @@
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341094,"type":105}
 @nix {"action":"stop","id":2981506167341089}
 @nix {"action":"stop","id":2981506167341090}
-@nix {"action":"start","fields":["/nix/store/0kzm0jjrfrx167f7h2qpc72naqgijjq6-build1","https://hydra.iohk.io"],"id":2981506167341095,"level":4,"text":"querying info about '/nix/store/0kzm0jjrfrx167f7h2qpc72naqgijjq6-build1' on 'https://hydra.iohk.io'","type":109}
-@nix {"action":"start","fields":["https://hydra.iohk.io/0kzm0jjrfrx167f7h2qpc72naqgijjq6.narinfo"],"id":2981506167341096,"level":4,"text":"downloading 'https://hydra.iohk.io/0kzm0jjrfrx167f7h2qpc72naqgijjq6.narinfo'","type":101}
+@nix {"action":"start","parent":0,"fields":["/nix/store/0kzm0jjrfrx167f7h2qpc72naqgijjq6-build1","https://hydra.iohk.io"],"id":2981506167341095,"level":4,"text":"querying info about '/nix/store/0kzm0jjrfrx167f7h2qpc72naqgijjq6-build1' on 'https://hydra.iohk.io'","type":109}
+@nix {"action":"start","parent":0,"fields":["https://hydra.iohk.io/0kzm0jjrfrx167f7h2qpc72naqgijjq6.narinfo"],"id":2981506167341096,"level":4,"text":"downloading 'https://hydra.iohk.io/0kzm0jjrfrx167f7h2qpc72naqgijjq6.narinfo'","type":101}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341086,"type":105}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341086,"type":105}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341092,"type":105}
@@ -850,8 +850,8 @@
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341096,"type":105}
 @nix {"action":"stop","id":2981506167341085}
 @nix {"action":"stop","id":2981506167341086}
-@nix {"action":"start","fields":["/nix/store/6wdndqhg7vzhn798icnhfsj5z0qxsxj5-build4","https://nixcache.reflex-frp.org"],"id":2981506167341097,"level":4,"text":"querying info about '/nix/store/6wdndqhg7vzhn798icnhfsj5z0qxsxj5-build4' on 'https://nixcache.reflex-frp.org'","type":109}
-@nix {"action":"start","fields":["https://nixcache.reflex-frp.org/6wdndqhg7vzhn798icnhfsj5z0qxsxj5.narinfo"],"id":2981506167341098,"level":4,"text":"downloading 'https://nixcache.reflex-frp.org/6wdndqhg7vzhn798icnhfsj5z0qxsxj5.narinfo'","type":101}
+@nix {"action":"start","parent":0,"fields":["/nix/store/6wdndqhg7vzhn798icnhfsj5z0qxsxj5-build4","https://nixcache.reflex-frp.org"],"id":2981506167341097,"level":4,"text":"querying info about '/nix/store/6wdndqhg7vzhn798icnhfsj5z0qxsxj5-build4' on 'https://nixcache.reflex-frp.org'","type":109}
+@nix {"action":"start","parent":0,"fields":["https://nixcache.reflex-frp.org/6wdndqhg7vzhn798icnhfsj5z0qxsxj5.narinfo"],"id":2981506167341098,"level":4,"text":"downloading 'https://nixcache.reflex-frp.org/6wdndqhg7vzhn798icnhfsj5z0qxsxj5.narinfo'","type":101}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341092,"type":105}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341092,"type":105}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341094,"type":105}
@@ -1011,8 +1011,8 @@
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341098,"type":105}
 @nix {"action":"stop","id":2981506167341091}
 @nix {"action":"stop","id":2981506167341092}
-@nix {"action":"start","fields":["/nix/store/dzzc2s66k3i9fhwnmyd32axq65gjdyf9-build3","https://hydra.iohk.io"],"id":2981506167341099,"level":4,"text":"querying info about '/nix/store/dzzc2s66k3i9fhwnmyd32axq65gjdyf9-build3' on 'https://hydra.iohk.io'","type":109}
-@nix {"action":"start","fields":["https://hydra.iohk.io/dzzc2s66k3i9fhwnmyd32axq65gjdyf9.narinfo"],"id":2981506167341100,"level":4,"text":"downloading 'https://hydra.iohk.io/dzzc2s66k3i9fhwnmyd32axq65gjdyf9.narinfo'","type":101}
+@nix {"action":"start","parent":0,"fields":["/nix/store/dzzc2s66k3i9fhwnmyd32axq65gjdyf9-build3","https://hydra.iohk.io"],"id":2981506167341099,"level":4,"text":"querying info about '/nix/store/dzzc2s66k3i9fhwnmyd32axq65gjdyf9-build3' on 'https://hydra.iohk.io'","type":109}
+@nix {"action":"start","parent":0,"fields":["https://hydra.iohk.io/dzzc2s66k3i9fhwnmyd32axq65gjdyf9.narinfo"],"id":2981506167341100,"level":4,"text":"downloading 'https://hydra.iohk.io/dzzc2s66k3i9fhwnmyd32axq65gjdyf9.narinfo'","type":101}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341094,"type":105}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341094,"type":105}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341098,"type":105}
@@ -1064,8 +1064,8 @@
 @nix {"action":"result","fields":[243,0,0,0],"id":2981506167341094,"type":105}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341098,"type":105}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341098,"type":105}
-@nix {"action":"start","fields":["/nix/store/pki9kcvm45p8whqa4nls5ipnlvgy4n9d-build2","https://hydra.iohk.io"],"id":2981506167341101,"level":4,"text":"querying info about '/nix/store/pki9kcvm45p8whqa4nls5ipnlvgy4n9d-build2' on 'https://hydra.iohk.io'","type":109}
-@nix {"action":"start","fields":["https://hydra.iohk.io/pki9kcvm45p8whqa4nls5ipnlvgy4n9d.narinfo"],"id":2981506167341102,"level":4,"text":"downloading 'https://hydra.iohk.io/pki9kcvm45p8whqa4nls5ipnlvgy4n9d.narinfo'","type":101}
+@nix {"action":"start","parent":0,"fields":["/nix/store/pki9kcvm45p8whqa4nls5ipnlvgy4n9d-build2","https://hydra.iohk.io"],"id":2981506167341101,"level":4,"text":"querying info about '/nix/store/pki9kcvm45p8whqa4nls5ipnlvgy4n9d-build2' on 'https://hydra.iohk.io'","type":109}
+@nix {"action":"start","parent":0,"fields":["https://hydra.iohk.io/pki9kcvm45p8whqa4nls5ipnlvgy4n9d.narinfo"],"id":2981506167341102,"level":4,"text":"downloading 'https://hydra.iohk.io/pki9kcvm45p8whqa4nls5ipnlvgy4n9d.narinfo'","type":101}
 @nix {"action":"stop","id":2981506167341093}
 @nix {"action":"stop","id":2981506167341094}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341098,"type":105}
@@ -1105,8 +1105,8 @@
 @nix {"action":"result","fields":[243,0,0,0],"id":2981506167341098,"type":105}
 @nix {"action":"stop","id":2981506167341097}
 @nix {"action":"stop","id":2981506167341098}
-@nix {"action":"start","fields":["/nix/store/6wdndqhg7vzhn798icnhfsj5z0qxsxj5-build4","https://hydra.iohk.io"],"id":2981506167341103,"level":4,"text":"querying info about '/nix/store/6wdndqhg7vzhn798icnhfsj5z0qxsxj5-build4' on 'https://hydra.iohk.io'","type":109}
-@nix {"action":"start","fields":["https://hydra.iohk.io/6wdndqhg7vzhn798icnhfsj5z0qxsxj5.narinfo"],"id":2981506167341104,"level":4,"text":"downloading 'https://hydra.iohk.io/6wdndqhg7vzhn798icnhfsj5z0qxsxj5.narinfo'","type":101}
+@nix {"action":"start","parent":0,"fields":["/nix/store/6wdndqhg7vzhn798icnhfsj5z0qxsxj5-build4","https://hydra.iohk.io"],"id":2981506167341103,"level":4,"text":"querying info about '/nix/store/6wdndqhg7vzhn798icnhfsj5z0qxsxj5-build4' on 'https://hydra.iohk.io'","type":109}
+@nix {"action":"start","parent":0,"fields":["https://hydra.iohk.io/6wdndqhg7vzhn798icnhfsj5z0qxsxj5.narinfo"],"id":2981506167341104,"level":4,"text":"downloading 'https://hydra.iohk.io/6wdndqhg7vzhn798icnhfsj5z0qxsxj5.narinfo'","type":101}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341104,"type":105}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341104,"type":105}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341104,"type":105}
@@ -1134,9 +1134,9 @@
 @nix {"action":"msg","level":3,"msg":"  /nix/store/nb5zj9zqm90jfly39s6v125zw8mvscqg-build2.drv"}
 @nix {"action":"msg","level":3,"msg":"  /nix/store/6l98vj7vfhdlvkxjprpbhixgla14nnil-build3.drv"}
 @nix {"action":"msg","level":3,"msg":"  /nix/store/x3009ywhj0gp826ysrghm5j4b7vx59lr-build4.drv"}
-@nix {"action":"start","id":2981506167341105,"level":0,"text":"","type":102}
-@nix {"action":"start","id":2981506167341106,"level":0,"text":"","type":104}
-@nix {"action":"start","id":2981506167341107,"level":0,"text":"","type":103}
+@nix {"action":"start","parent":0,"id":2981506167341105,"level":0,"text":"","type":102}
+@nix {"action":"start","parent":0,"id":2981506167341106,"level":0,"text":"","type":104}
+@nix {"action":"start","parent":0,"id":2981506167341107,"level":0,"text":"","type":103}
 @nix {"action":"result","fields":[0,1,0,0],"id":2981506167341106,"type":105}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341107,"type":105}
 @nix {"action":"result","fields":[101,0],"id":2981506167341105,"type":106}
@@ -1153,9 +1153,9 @@
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341107,"type":105}
 @nix {"action":"result","fields":[101,0],"id":2981506167341105,"type":106}
 @nix {"action":"result","fields":[100,0],"id":2981506167341105,"type":106}
-@nix {"action":"start","id":2981506167341108,"level":6,"text":"querying info about missing paths","type":0}
+@nix {"action":"start","parent":0,"id":2981506167341108,"level":6,"text":"querying info about missing paths","type":0}
 @nix {"action":"stop","id":2981506167341108}
-@nix {"action":"start","fields":["/nix/store/w5afkqmj662l56mcwmw5ijh1kfllxsap-build1.drv","",1,1],"id":2981506167341109,"level":3,"text":"building '/nix/store/w5afkqmj662l56mcwmw5ijh1kfllxsap-build1.drv'","type":105}
+@nix {"action":"start","parent":0,"fields":["/nix/store/w5afkqmj662l56mcwmw5ijh1kfllxsap-build1.drv","",1,1],"id":2981506167341109,"level":3,"text":"building '/nix/store/w5afkqmj662l56mcwmw5ijh1kfllxsap-build1.drv'","type":105}
 @nix {"action":"result","fields":[0,4,1,0],"id":2981506167341106,"type":105}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341107,"type":105}
 @nix {"action":"result","fields":[101,0],"id":2981506167341105,"type":106}
@@ -1166,7 +1166,7 @@
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341107,"type":105}
 @nix {"action":"result","fields":[101,0],"id":2981506167341105,"type":106}
 @nix {"action":"result","fields":[100,0],"id":2981506167341105,"type":106}
-@nix {"action":"start","fields":["/nix/store/nb5zj9zqm90jfly39s6v125zw8mvscqg-build2.drv","",1,1],"id":2981506167341110,"level":3,"text":"building '/nix/store/nb5zj9zqm90jfly39s6v125zw8mvscqg-build2.drv'","type":105}
+@nix {"action":"start","parent":0,"fields":["/nix/store/nb5zj9zqm90jfly39s6v125zw8mvscqg-build2.drv","",1,1],"id":2981506167341110,"level":3,"text":"building '/nix/store/nb5zj9zqm90jfly39s6v125zw8mvscqg-build2.drv'","type":105}
 @nix {"action":"result","fields":[1,4,1,0],"id":2981506167341106,"type":105}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341107,"type":105}
 @nix {"action":"result","fields":[101,0],"id":2981506167341105,"type":106}
@@ -1177,7 +1177,7 @@
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341107,"type":105}
 @nix {"action":"result","fields":[101,0],"id":2981506167341105,"type":106}
 @nix {"action":"result","fields":[100,0],"id":2981506167341105,"type":106}
-@nix {"action":"start","fields":["/nix/store/6l98vj7vfhdlvkxjprpbhixgla14nnil-build3.drv","",1,1],"id":2981506167341111,"level":3,"text":"building '/nix/store/6l98vj7vfhdlvkxjprpbhixgla14nnil-build3.drv'","type":105}
+@nix {"action":"start","parent":0,"fields":["/nix/store/6l98vj7vfhdlvkxjprpbhixgla14nnil-build3.drv","",1,1],"id":2981506167341111,"level":3,"text":"building '/nix/store/6l98vj7vfhdlvkxjprpbhixgla14nnil-build3.drv'","type":105}
 @nix {"action":"result","fields":[2,4,1,0],"id":2981506167341106,"type":105}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341107,"type":105}
 @nix {"action":"result","fields":[101,0],"id":2981506167341105,"type":106}
@@ -1188,7 +1188,7 @@
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341107,"type":105}
 @nix {"action":"result","fields":[101,0],"id":2981506167341105,"type":106}
 @nix {"action":"result","fields":[100,0],"id":2981506167341105,"type":106}
-@nix {"action":"start","fields":["/nix/store/x3009ywhj0gp826ysrghm5j4b7vx59lr-build4.drv","",1,1],"id":2981506167341112,"level":3,"text":"building '/nix/store/x3009ywhj0gp826ysrghm5j4b7vx59lr-build4.drv'","type":105}
+@nix {"action":"start","parent":0,"fields":["/nix/store/x3009ywhj0gp826ysrghm5j4b7vx59lr-build4.drv","",1,1],"id":2981506167341112,"level":3,"text":"building '/nix/store/x3009ywhj0gp826ysrghm5j4b7vx59lr-build4.drv'","type":105}
 @nix {"action":"result","fields":[3,4,1,0],"id":2981506167341106,"type":105}
 @nix {"action":"result","fields":[0,0,0,0],"id":2981506167341107,"type":105}
 @nix {"action":"result","fields":[101,0],"id":2981506167341105,"type":106}


### PR DESCRIPTION
## Summary

When using `--store "ssh-ng://..."`, Nix reports builds with empty host field in JSON output. nom was treating these as localhost. Now we detect the remote store from upload activities (which do have correct host info) and use that for builds.

## Test plan

- Tested local builds
- Tested `--store "ssh-ng://..."` builds - now correctly attributed to remote host
- Tested `--builders "ssh://..."` builds - works as before
- Verified no parse errors for large activity IDs