### PR TITLE
devShell: add hlint

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -113,6 +113,7 @@
             (lib.getBin pkgs.haskellPackages.fourmolu)
             git-hooks.packages.${system}.default
             pkgs.haskell-language-server
+            pkgs.hlint
             (lib.getBin pkgs.haskellPackages.weeder)
             pkgs.cabal-install
             pkgs.pv


### PR DESCRIPTION
It seems to be enabled for pre-commit hooks, but isn't otherwise available on $PATH.