### PR TITLE
Corrected completion files in nix-output-monitor.cabal

### DIFF
--- a/nix-output-monitor.cabal
+++ b/nix-output-monitor.cabal
@@ -15,8 +15,9 @@ author: maralorn <mail@maralorn.de>
 maintainer: maralorn <mail@maralorn.de>
 build-type: Simple
 extra-source-files:
-  completions/completion.bash
-  completions/completion.zsh
+  completions/nom.bash
+  completions/nom.zsh
+  completions/nom.fish
   test/golden/fail/stderr
   test/golden/fail/stderr.json
   test/golden/fail/stdout


### PR DESCRIPTION
completion files listed in extra-source-files should match files included in the source.