### PR TITLE
fix: use Word for activity IDs to handle large unsigned values

### DIFF
--- a/lib/NOM/NixMessage/JSON.hs
+++ b/lib/NOM/NixMessage/JSON.hs
@@ -5,7 +5,7 @@ import NOM.Error (NOMError)
 import Optics.TH (makeFieldLabelsNoPrefix)
 import Relude
 
-newtype ActivityId = MkId {value :: Int}
+newtype ActivityId = MkId {value :: Word}
   deriving newtype (Show, Eq, Ord)
 
 makeFieldLabelsNoPrefix ''ActivityId

--- a/lib/NOM/Parser/JSON.hs
+++ b/lib/NOM/Parser/JSON.hs
@@ -104,7 +104,7 @@ four listdec = do
 
 parseResultAction :: JSON.FieldsDecoder ResultAction
 parseResultAction = do
-  idField <- MkId <$> JSON.atKey "id" JSON.int
+  idField <- MkId <$> JSON.atKey "id" JSON.uint
   type' <- JSON.atKey "type" JSON.int
   let txt = textFields
   let num = intFields
@@ -125,11 +125,11 @@ parseResultAction = do
   pure MkResultAction{id = idField, result}
 
 parseStopAction :: JSON.FieldsDecoder StopAction
-parseStopAction = MkStopAction . MkId <$> JSON.atKey "id" JSON.int
+parseStopAction = MkStopAction . MkId <$> JSON.atKey "id" JSON.uint
 
 parseStartAction :: JSON.FieldsDecoder StartAction
 parseStartAction = do
-  idField <- JSON.atKey "id" JSON.int
+  idField <- JSON.atKey "id" JSON.uint
   text <- JSON.atKey "text" JSON.text
   level <- JSON.atKey "level" parseVerbosity
   activityType <- JSON.atKey "type" (JSON.withInt parseActivityType)

--- a/lib/NOM/Print.hs
+++ b/lib/NOM/Print.hs
@@ -527,7 +527,7 @@ printBuilds nomState@MkNOMState{..} hostAbbrevs limits = printBuildsWithTime
         activityField :: Lens' ActivityStatus (Strict.Maybe a) -> Strict.Maybe ActivityId -> Maybe a
         activityField field activityId' = do
           activityId <- Strict.toLazy activityId'
-          activity_status <- IntMap.lookup activityId.value nomState.activities
+          activity_status <- Map.lookup activityId.value nomState.activities
           Strict.toLazy $ view field activity_status
         progressMay = activityField #progress
         phaseMay = activityField #phase

--- a/lib/NOM/State.hs
+++ b/lib/NOM/State.hs
@@ -254,11 +254,11 @@ data NOMState = MkNOMState
   , storePathIds :: Map StorePath StorePathId
   , derivationIds :: Map Derivation DerivationId
   , touchedIds :: DerivationSet
-  , activities :: IntMap ActivityStatus
+  , activities :: Map Word ActivityStatus
   , nixErrors :: Seq Text
   , nixTraces :: Seq Text
   , buildPlatform :: Strict.Maybe Text
-  , interestingActivities :: IntMap InterestingActivity
+  , interestingActivities :: Map Word InterestingActivity
   , evaluationState :: EvalInfo
   , successTokens :: Int
   , buildsActivity :: Strict.Maybe ActivityId


### PR DESCRIPTION
Nix sends activity IDs as unsigned 64-bit integers which can exceed
the range of signed Int. Changed ActivityId to use Word and parse
with uint decoder. Changed activities and interestingActivities maps
from IntMap to Map Word for type safety.
