### PR TITLE
Add bash completion for `nom-build` and `nom-shell`

### DIFF
--- a/completions/nom-build.bash
+++ b/completions/nom-build.bash
@@ -1,0 +1,7 @@
+__load_completion nix-build
+_nom_build_completion() {
+    COMP_WORDS[0]=nix-build
+    COMP_LINE="nix-build${COMP_LINE#nom-build}"
+    _nix_completion
+}
+complete -F _nom_build_completion nom-build

--- a/completions/nom-shell.bash
+++ b/completions/nom-shell.bash
@@ -1,0 +1,7 @@
+__load_completion nix-shell
+_nom_shell_completion() {
+    COMP_WORDS[0]=nix-shell
+    COMP_LINE="nix-shell${COMP_LINE#nom-shell}"
+    _nix_completion
+}
+complete -F _nom_shell_completion nom-shell

--- a/nix-output-monitor.cabal
+++ b/nix-output-monitor.cabal
@@ -15,7 +15,9 @@ author: maralorn <mail@maralorn.de>
 maintainer: maralorn <mail@maralorn.de>
 build-type: Simple
 extra-source-files:
+  completions/nom-build.bash
   completions/nom-build.zsh
+  completions/nom-shell.bash
   completions/nom-shell.zsh
   completions/nom.bash
   completions/nom.fish


### PR DESCRIPTION
These wrappers delegate to the system's `nix-build`/`nix-shell` completion by rewriting `COMP_WORDS[0]` and `COMP_LINE` to make `_nix_completion` think the corresponding nix command was typed.

Tested with Nix 2.33.1 and Lix 2.94.0.