### PR TITLE
Use inotify to wait on store paths

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,8 +1,9 @@
 { mkDerivation, ansi-terminal, async, attoparsec, base, bytestring
 , cassava, containers, directory, extra, filelock, filepath
-, hermes-json, HUnit, lib, nix-derivation, optics, random, relude
-, safe, safe-exceptions, stm, streamly-core, strict, terminal-size
-, text, time, transformers, typed-process, unix, word8
+, hermes-json, hinotify, HUnit, lib, nix-derivation, optics, random
+, relude, safe, safe-exceptions, stm, streamly-core, strict
+, terminal-size, text, time, transformers, typed-process, unix
+, word8
 }:
 mkDerivation {
   pname = "nix-output-monitor";
@@ -12,24 +13,26 @@ mkDerivation {
   isExecutable = true;
   libraryHaskellDepends = [
     ansi-terminal async attoparsec base bytestring cassava containers
-    directory extra filelock filepath hermes-json nix-derivation optics
-    relude safe safe-exceptions stm streamly-core strict terminal-size
-    text time transformers word8
+    directory extra filelock filepath hermes-json hinotify
+    nix-derivation optics relude safe safe-exceptions stm streamly-core
+    strict terminal-size text time transformers word8
   ];
   executableHaskellDepends = [
     ansi-terminal async attoparsec base bytestring cassava containers
-    directory extra filelock filepath hermes-json nix-derivation optics
-    relude safe safe-exceptions stm streamly-core strict terminal-size
-    text time transformers typed-process unix word8
+    directory extra filelock filepath hermes-json hinotify
+    nix-derivation optics relude safe safe-exceptions stm streamly-core
+    strict terminal-size text time transformers typed-process unix
+    word8
   ];
   testHaskellDepends = [
     ansi-terminal async attoparsec base bytestring cassava containers
-    directory extra filelock filepath hermes-json HUnit nix-derivation
-    optics random relude safe safe-exceptions stm streamly-core strict
-    terminal-size text time transformers typed-process word8
+    directory extra filelock filepath hermes-json hinotify HUnit
+    nix-derivation optics random relude safe safe-exceptions stm
+    streamly-core strict terminal-size text time transformers
+    typed-process word8
   ];
   homepage = "https://code.maralorn.de/maralorn/nix-output-monitor";
   description = "Processes output of Nix commands to show helpful and pretty information";
-  license = "EUPL-1.2";
+  license = lib.licensesSpdx."EUPL-1.2";
   mainProgram = "nom";
 }

--- a/lib/NOM/IO.hs
+++ b/lib/NOM/IO.hs
@@ -18,6 +18,7 @@ import Streamly.Data.Stream qualified as Stream
 import System.Console.ANSI (SGR (Reset), setSGRCode)
 import System.Console.ANSI qualified as Terminal
 import System.Console.Terminal.Size qualified as Terminal.Size
+import System.INotify
 import System.IO qualified
 
 type Stream = Stream.Stream IO
@@ -36,17 +37,18 @@ type Window = Terminal.Size.Window Int
 
 runUpdate ::
   forall update state.
+  INotify ->
   TVar [ByteString] ->
   TMVar state ->
   TVar Bool ->
   UpdateFunc update state ->
   update ->
   IO ()
-runUpdate output_builder_var state_var refresh_display_var updater input = do
+runUpdate inotify output_builder_var state_var refresh_display_var updater input = do
   -- Since we are taking the state_var here we prevent any other state update
   -- to happen simultaneously.
   old_state <- atomically $ takeTMVar state_var
-  ((errors, log_output, display_changed), !newState) <- runStateT (updater input) old_state
+  ((errors, log_output, display_changed), !newState) <- runReaderT (runStateT (updater input) old_state) inotify
   atomically $ do
     forM_ errors (writeErrorToBuilder output_builder_var)
     putTMVar state_var newState
@@ -235,27 +237,28 @@ processTextStream config parser updater maintenance printerMay finalize initialS
   state_var <- newTMVarIO initialState
   output_builder_var <- newTVarIO []
   refresh_display_var <- newTVarIO False
-  let keepProcessing :: IO ()
-      keepProcessing =
-        inputStream
-          & Stream.tap (errorsToBuilderFold output_builder_var)
-          & Stream.mapMaybe rightToMaybe
-          & parser
-          & Stream.fold (Fold.drainMapM (runUpdate output_builder_var state_var refresh_display_var updater))
-      waitForInput :: IO ()
-      waitForInput = atomically $ check =<< readTVar refresh_display_var
-  printerMay & maybe keepProcessing \(printer, output_handle) -> do
-    linesVar <- newTVarIO 0
-    let writeToScreen :: IO ()
-        writeToScreen = writeStateToScreen (not config.silent) linesVar state_var output_builder_var refresh_display_var maintenance printer output_handle
-        keepPrinting :: IO ()
-        keepPrinting = forever do
-          race_ (concurrently_ (threadDelay minFrameDuration) waitForInput) (threadDelay maxFrameDuration)
-          writeToScreen
-    race_ keepProcessing keepPrinting
-    atomically (takeTMVar state_var) >>= execStateT finalize >>= atomically . putTMVar state_var
-    writeToScreen
-  (if isNothing printerMay then (>>= execStateT finalize) else id) $ atomically $ takeTMVar state_var
+  withINotify \inotify -> do
+    let keepProcessing :: IO ()
+        keepProcessing =
+          inputStream
+            & Stream.tap (errorsToBuilderFold output_builder_var)
+            & Stream.mapMaybe rightToMaybe
+            & parser
+            & Stream.fold (Fold.drainMapM (runUpdate inotify output_builder_var state_var refresh_display_var updater))
+        waitForInput :: IO ()
+        waitForInput = atomically $ check =<< readTVar refresh_display_var
+    printerMay & maybe keepProcessing \(printer, output_handle) -> do
+      linesVar <- newTVarIO 0
+      let writeToScreen :: IO ()
+          writeToScreen = writeStateToScreen (not config.silent) linesVar state_var output_builder_var refresh_display_var maintenance printer output_handle
+          keepPrinting :: IO ()
+          keepPrinting = forever do
+            race_ (concurrently_ (threadDelay minFrameDuration) waitForInput) (threadDelay maxFrameDuration)
+            writeToScreen
+      race_ keepProcessing keepPrinting
+      atomically (takeTMVar state_var) >>= \s -> runReaderT (execStateT finalize s) inotify >>= atomically . putTMVar state_var
+      writeToScreen
+    (if isNothing printerMay then (>>= \s -> runReaderT (execStateT finalize s) inotify) else id) $ atomically $ takeTMVar state_var
 
 errorsToBuilderFold :: TVar [ByteString] -> Fold.Fold IO (Either NOMError ByteString) ()
 errorsToBuilderFold builder_var = Fold.drainMapM saveInput

--- a/lib/NOM/State.hs
+++ b/lib/NOM/State.hs
@@ -43,6 +43,7 @@ module NOM.State (
   OutputName (..),
 ) where
 
+import Control.Concurrent.Async (Async)
 import Data.Map.Strict qualified as Map
 import Data.Set qualified as Set
 import Data.Strict qualified as Strict
@@ -260,8 +261,8 @@ data NOMState = MkNOMState
   , buildPlatform :: Strict.Maybe Text
   , interestingActivities :: Map Word InterestingActivity
   , evaluationState :: EvalInfo
+  , waitingDerivations :: Map (Host WithContext, DerivationId) (Async ())
   }
-  deriving stock (Show, Eq, Ord)
 
 makeFieldLabelsNoPrefix ''NOMState
 
@@ -287,6 +288,7 @@ initalStateFromBuildPlatform platform = do
       (Strict.toStrict platform)
       mempty
       MkEvalInfo{count = 0, at = 0, lastFileName = Strict.Nothing}
+      mempty
 
 instance Semigroup DependencySummary where
   (MkDependencySummary ls1 lm2 lm3 lm4 ls5 lm6 lm7 lm8 lm9) <> (MkDependencySummary rs1 rm2 rm3 rm4 rs5 rm6 rm7 rm8 rm9) = MkDependencySummary (ls1 <> rs1) (lm2 <> rm2) (lm3 <> rm3) (lm4 <> rm4) (ls5 <> rs5) (lm6 <> rm6) (lm7 <> rm7) (lm8 <> rm8) (lm9 <> rm9)

--- a/lib/NOM/Update.hs
+++ b/lib/NOM/Update.hs
@@ -69,6 +69,7 @@ import Numeric.Extra (intToDouble)
 import Optics (Ixed (..), assign', has, modifying', preuse, preview, (%), (%~), (.~))
 import Relude
 import System.Console.ANSI (SGR (Reset), setSGRCode)
+import System.Timeout (timeout)
 
 type ProcessingT m a = (UpdateMonad m, MonadNOMState m) => WriterT [Either NOMError ByteString] m a
 
@@ -279,8 +280,12 @@ processJsonMessage = \case
         drvId <- lookupDerivation drv
         isCompleted <-
           derivationToAnyOutPath drvId >>= \case
-            Nothing -> pure False -- Derivation has no "out" output.
-            Just path -> waitForStorePath path -- Blocks up to 500ms. This should probably be fixed by doing something smart wtih concurrency.
+            Nothing -> pure True -- Derivation has no "out" output.
+            Just path -> do
+              inotify <- theInotify
+              liftIO do
+                result <- timeout 1_000_000 $ runReaderT (waitForStorePath path) inotify
+                pure $ isJust result
         if isCompleted then withChange $ finishBuildByDrvId host drvId else noChange
       _ -> pure (isJust interesting_activity)
   Plain msg -> tell [Right msg] >> noChange

--- a/lib/NOM/Update/Monad.hs
+++ b/lib/NOM/Update/Monad.hs
@@ -7,8 +7,6 @@ module NOM.Update.Monad (
   module NOM.Update.Monad.CacheBuildReports,
 ) where
 
-import Control.Concurrent (threadDelay)
-import Control.Concurrent.Async
 import Control.Concurrent.STM (retry)
 import Control.Exception (bracket, try)
 import Control.Monad.Trans.Writer.CPS (WriterT)
@@ -98,33 +96,20 @@ instance MonadCheckStorePath Update where
         rawStore = encodeUtf8 . takeDirectory $ toString path
     found <- newTVarIO False
 
-    liftIO
-      $ withAsync
-        do
-          fix \k -> do
-            there <- storePathExistsIO path
-            if there
-              then do
-                threadDelay 500_000
-                k
-              else atomically $ writeTVar found True
-        \pathPoller -> do
-          link pathPoller
-
-          found0 <- readTVarIO found
-
-          if found0
-            then pure ()
-            else do
-              liftIO $ bracket
-                ( addWatch inotify [MoveIn] rawStore \case
-                    MovedIn{filePath} | filePath == rawStorePath -> atomically $ writeTVar found True
-                    _ -> pure ()
-                )
-                removeWatch
-                \_ -> atomically do
-                  found1 <- readTVar found
-                  unless found1 retry
+    liftIO $ bracket
+      ( addWatch inotify [AllEvents] rawStore \case
+          MovedIn{filePath}
+            | rawStore <> "/" <> filePath == rawStorePath ->
+                atomically $ writeTVar found True
+          _ -> pure ()
+      )
+      removeWatch
+      \_ -> do
+        there <- storePathExistsIO path
+        when there $ atomically $ writeTVar found True
+        atomically do
+          found1 <- readTVar found
+          unless found1 retry
 
 instance (MonadCheckStorePath m) => MonadCheckStorePath (StateT a m) where
   storePathExists = lift . storePathExists

--- a/lib/NOM/Update/Monad.hs
+++ b/lib/NOM/Update/Monad.hs
@@ -3,11 +3,14 @@ module NOM.Update.Monad (
   MonadNow (..),
   MonadReadDerivation (..),
   MonadCheckStorePath (..),
+  Update,
   module NOM.Update.Monad.CacheBuildReports,
 ) where
 
 import Control.Concurrent (threadDelay)
-import Control.Exception (try)
+import Control.Concurrent.Async
+import Control.Concurrent.STM (retry)
+import Control.Exception (bracket, try)
 import Control.Monad.Trans.Writer.CPS (WriterT)
 import Data.Attoparsec.Text (eitherResult, parse)
 import Data.Text.IO qualified as TextIO
@@ -19,8 +22,11 @@ import NOM.Update.Monad.CacheBuildReports
 import Nix.Derivation qualified as Nix
 import Relude
 import System.Directory (doesPathExist)
+import System.FilePath (takeDirectory)
+import System.INotify
 
-type UpdateMonad m = (Monad m, MonadNow m, MonadReadDerivation m, MonadCacheBuildReports m, MonadCheckStorePath m)
+-- the MonadIO kind of defeats the point here, but we need it to partially "unlift" back into IO
+type UpdateMonad m = (Monad m, MonadIO m, MonadNow m, MonadReadDerivation m, MonadCacheBuildReports m, MonadCheckStorePath m)
 
 class (Monad m) => MonadNow m where
   getNow :: m Double
@@ -35,6 +41,10 @@ instance (MonadNow m) => MonadNow (StateT a m) where
   getUTC = lift getUTC
 
 instance (MonadNow m) => MonadNow (WriterT a m) where
+  getNow = lift getNow
+  getUTC = lift getUTC
+
+instance (MonadNow m) => MonadNow (ReaderT a m) where
   getNow = lift getNow
   getUTC = lift getUTC
 
@@ -62,25 +72,66 @@ instance (MonadReadDerivation m) => MonadReadDerivation (ExceptT a m) where
 instance (MonadReadDerivation m) => MonadReadDerivation (WriterT a m) where
   getDerivation = lift . getDerivation
 
+instance (MonadReadDerivation m) => MonadReadDerivation (ReaderT a m) where
+  getDerivation = lift . getDerivation
+
+type Update = ReaderT INotify IO
+
 class (Monad m) => MonadCheckStorePath m where
   storePathExists :: StorePath -> m Bool
-  waitForStorePath :: StorePath -> m Bool
 
-instance MonadCheckStorePath IO where
-  storePathExists = doesPathExist . toString
-  waitForStorePath path = go 5
-   where
-    go (count :: Nat) = do
-      there <- storePathExists path
-      if
-        | there -> pure True
-        | count <= 0 -> pure False
-        | otherwise -> threadDelay 100_000 >> go (count - 1)
+  -- | WILL block indefinitely if the store path is not going to exist. Use with a timeout.
+  waitForStorePath :: StorePath -> m ()
+
+  -- | Implementation detail. Added only because of the monad transformer stack being annoying
+  theInotify :: m INotify
+
+storePathExistsIO :: StorePath -> IO Bool
+storePathExistsIO = doesPathExist . toString
+
+instance MonadCheckStorePath Update where
+  theInotify = ask
+  storePathExists = liftIO . storePathExistsIO
+  waitForStorePath path = do
+    inotify <- ask
+    let rawStorePath = encodeUtf8 (toString path)
+        rawStore = encodeUtf8 . takeDirectory $ toString path
+    found <- newTVarIO False
+
+    liftIO
+      $ withAsync
+        do
+          fix \k -> do
+            there <- storePathExistsIO path
+            if there
+              then do
+                threadDelay 500_000
+                k
+              else atomically $ writeTVar found True
+        \pathPoller -> do
+          link pathPoller
+
+          found0 <- readTVarIO found
+
+          if found0
+            then pure ()
+            else do
+              liftIO $ bracket
+                ( addWatch inotify [MoveIn] rawStore \case
+                    MovedIn{filePath} | filePath == rawStorePath -> atomically $ writeTVar found True
+                    _ -> pure ()
+                )
+                removeWatch
+                \_ -> atomically do
+                  found1 <- readTVar found
+                  unless found1 retry
 
 instance (MonadCheckStorePath m) => MonadCheckStorePath (StateT a m) where
   storePathExists = lift . storePathExists
   waitForStorePath = lift . waitForStorePath
+  theInotify = lift theInotify
 
 instance (MonadCheckStorePath m) => MonadCheckStorePath (WriterT a m) where
   storePathExists = lift . storePathExists
   waitForStorePath = lift . waitForStorePath
+  theInotify = lift theInotify

--- a/lib/NOM/Update/Monad/CacheBuildReports.hs
+++ b/lib/NOM/Update/Monad/CacheBuildReports.hs
@@ -50,6 +50,10 @@ instance (MonadCacheBuildReports m) => MonadCacheBuildReports (WriterT a m) wher
   getCachedBuildReports = lift getCachedBuildReports
   updateBuildReports = lift . updateBuildReports
 
+instance (MonadCacheBuildReports m) => MonadCacheBuildReports (ReaderT a m) where
+  getCachedBuildReports = lift getCachedBuildReports
+  updateBuildReports = lift . updateBuildReports
+
 -- Implementation
 
 tryUpdateBuildReports :: (BuildReportMap -> BuildReportMap) -> IO BuildReportMap

--- a/nix-output-monitor.cabal
+++ b/nix-output-monitor.cabal
@@ -79,6 +79,7 @@ common common-config
     filelock,
     filepath,
     hermes-json >=0.6.0.0,
+    hinotify,
     nix-derivation,
     optics,
     relude,


### PR DESCRIPTION
Done at Zurihac. Currently quite hacky (e.g. requires adding a `MonadIO` constraint to `UpdateMonad`, which kind of defeats the point of the design). `waitOnStorePath` still blocks and waits on only one store path at a time as before, but this could be avoided with more extensive changes.