### PR TITLE
Refactor test to use streaming

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -112,7 +112,7 @@
             ];
             hooks = {
               hlint.enable = true;
-              nixfmt-rfc-style = {
+              nixfmt = {
                 enable = true;
                 excludes = [ "^default.nix" ];
               };

--- a/nixos-test.nix
+++ b/nixos-test.nix
@@ -25,12 +25,6 @@ runNixOSTest {
 
       settings = {
         substitute = false;
-
-        # nom testsuite uses nix-command, probably flakes
-        experimental-features = [
-          "nix-command"
-          "flakes"
-        ];
         # When building a, b, c where a depends on b, c should build instead of being pending to match the golden files.
         max-jobs = 4;
       };

--- a/test/Golden.hs
+++ b/test/Golden.hs
@@ -68,15 +68,11 @@ data TestConfig = MkTestConfig {withNix :: Bool, oldStyle :: Bool}
 
 streamFromNixCommand ::
   TestConfig ->
-  Process.ProcessConfig () () () ->
+  Process.ProcessConfig () (STM LByteString) Handle ->
   (Stream.Stream IO ByteString -> IO r) ->
   IO (r, Text, Process.ExitCode)
 streamFromNixCommand test_config process_config use_stream = do
-  let process_config_with_handles =
-        process_config
-          & Process.setStdout Process.byteStringOutput
-          & Process.setStderr Process.createPipe
-  Process.withProcessWait process_config_with_handles \process -> do
+  Process.withProcessWait process_config \process -> do
     let err = Stream.catRights $ (if test_config.oldStyle then inputStream OldStyleInput else inputStream NixJSONMessage) (Process.getStderr process)
     result <- use_stream err
     exitCode <- Process.waitExitCode process
@@ -104,8 +100,11 @@ testBuild name config asserts =
          where
           command =
             Process.proc "nix-build"
-              $ ["test/golden/" <> name <> "/default.nix", "--no-out-link", "--argstr", "seed", show seed]
+              ( ["test/golden/" <> name <> "/default.nix", "--no-out-link", "--argstr", "seed", show seed]
               <> if config.oldStyle then [] else ["-v", "--log-format", "internal-json"]
+              )
+              & Process.setStdout Process.byteStringOutput
+              & Process.setStderr Process.createPipe
 
     (end_state, output, _) <- go if config.oldStyle then testProcess @OldStyleInput else testProcess @NixJSONMessage
 

--- a/test/Golden.hs
+++ b/test/Golden.hs
@@ -93,7 +93,7 @@ streamFromFiles name config use_stream = do
   let suffix = if config.oldStyle then "" else ".json"
   out <- readFileBS ("test/golden/" <> name <> "/stdout" <> suffix)
   err <- readFileBS ("test/golden/" <> name <> "/stderr" <> suffix)
-  result <- use_stream (Stream.fromPure err)
+  result <- use_stream $ if config.oldStyle then Stream.fromPure err else Stream.fromList (ByteString.lines err)
   pure (result, pure (decodeUtf8 out), Process.ExitSuccess)
 
 testBuild :: String -> TestConfig -> (Text -> NOMState -> IO ()) -> Test

--- a/test/Golden.hs
+++ b/test/Golden.hs
@@ -66,30 +66,29 @@ main = do
 
 data TestConfig = MkTestConfig {withNix :: Bool, oldStyle :: Bool}
 
-streamNixCommand ::
+streamFromNixCommand ::
   TestConfig ->
   Process.ProcessConfig () () () ->
   (Stream.Stream IO ByteString -> IO r) ->
   IO (r, STM Text, Process.ExitCode)
-streamNixCommand test_config process_config use_stream = do
+streamFromNixCommand test_config process_config use_stream = do
   let process_config_with_handles =
-        Process.setStdout Process.byteStringOutput
-          . Process.setStderr Process.createPipe
-          $ process_config
-  Process.withProcessWait @IO process_config_with_handles \process -> do
+        process_config
+          & Process.setStdout Process.byteStringOutput
+          & Process.setStderr Process.createPipe
+  Process.withProcessWait process_config_with_handles \process -> do
     let out = decodeUtf8 <$> Process.getStdout process
     let err = Stream.catRights $ (if test_config.oldStyle then inputStream OldStyleInput else inputStream NixJSONMessage) (Process.getStderr process)
-
     result <- use_stream err
     exitCode <- Process.waitExitCode process
     pure (result, out, exitCode)
 
-streamFromFiles ::
+streamFromGoldenFiles ::
   String ->
   TestConfig ->
   (Stream.Stream IO ByteString -> IO r) ->
   IO (r, STM Text, Process.ExitCode)
-streamFromFiles name config use_stream = do
+streamFromGoldenFiles name config use_stream = do
   let suffix = if config.oldStyle then "" else ".json"
   out <- readFileBS ("test/golden/" <> name <> "/stdout" <> suffix)
   err <- readFileBS ("test/golden/" <> name <> "/stderr" <> suffix)
@@ -100,24 +99,18 @@ testBuild :: String -> TestConfig -> (Text -> NOMState -> IO ()) -> Test
 testBuild name config asserts =
   label config name ~: do
     seed <- randomIO @Int
-    let go = if config.withNix then streamNixCommand config command else streamFromFiles name config
+    let go = if config.withNix then streamFromNixCommand config command else streamFromGoldenFiles name config
          where
           command =
-            if config.oldStyle
-              then
-                Process.proc
-                  "nix-build"
-                  ["test/golden/" <> name <> "/default.nix", "--no-out-link", "--argstr", "seed", show seed]
-              else
-                Process.proc
-                  "nix-build"
-                  ["test/golden/" <> name <> "/default.nix", "--no-out-link", "--argstr", "seed", show seed, "-v", "--log-format", "internal-json"]
+            Process.proc "nix-build"
+              $ ["test/golden/" <> name <> "/default.nix", "--no-out-link", "--argstr", "seed", show seed]
+              <> if config.oldStyle then [] else ["-v", "--log-format", "internal-json"]
 
-    (end_state, output, _) <- go (if config.oldStyle then testProcess @OldStyleInput else testProcess @NixJSONMessage)
-    output' <- atomically output
+    (end_state, output_var, _) <- go (if config.oldStyle then testProcess @OldStyleInput else testProcess @NixJSONMessage)
 
-    onException (asserts output' end_state) $ do
-      TextIO.putStrLn output'
+    output <- atomically output_var
+    onException (asserts output end_state) $ do
+      TextIO.putStrLn output
       print end_state
 
 testProcess :: forall input. (NOMInput input) => Stream.Stream IO ByteString -> IO NOMState

--- a/test/Golden.hs
+++ b/test/Golden.hs
@@ -117,7 +117,6 @@ testBuild name config asserts =
     (end_state, output, _) <- go (if config.oldStyle then testProcess @OldStyleInput else testProcess @NixJSONMessage)
     output' <- atomically output
 
-    -- TODO(leana8959): how do I consume the stream for the assertion without running IO twice?
     onException (asserts output' end_state) $ do
       TextIO.putStrLn output'
       print end_state

--- a/test/Golden.hs
+++ b/test/Golden.hs
@@ -8,7 +8,7 @@ import Data.Text qualified as Text
 import NOM.Builds (parseStorePath)
 import NOM.Error (NOMError)
 import NOM.IO (processTextStream)
-import NOM.IO.Input (NOMInput (..), UpdateResult (..))
+import NOM.IO.Input (NOMInput (..), UpdateResult (..), inputStream)
 import NOM.IO.Input.JSON ()
 import NOM.IO.Input.OldStyle (OldStyleInput)
 import NOM.NixMessage.JSON (NixJSONMessage)
@@ -65,30 +65,62 @@ main = do
 
 data TestConfig = MkTestConfig {withNix :: Bool, oldStyle :: Bool}
 
+
+streamNixCommand ::
+  TestConfig ->
+  Process.ProcessConfig () () () ->
+  ((Stream.Stream IO Text, Stream.Stream IO ByteString) -> IO r) ->
+  IO (r, Process.ExitCode)
+streamNixCommand test_config process_config use_stream = do
+  let process_config_with_handles =
+        Process.setStdout Process.createPipe
+          . Process.setStderr Process.createPipe
+          $ process_config
+  Process.withProcessWait @IO process_config_with_handles \process -> do
+    let stdout = Stream.catRights $ (if test_config.oldStyle then inputStream OldStyleInput else inputStream NixJSONMessage) (Process.getStdout process)
+    let stderr = Stream.catRights $ (if test_config.oldStyle then inputStream OldStyleInput else inputStream NixJSONMessage) (Process.getStderr process)
+
+    -- TODO(leana8959): deal with the errors within the streams
+    result <- use_stream (decodeUtf8 <$> stdout, stderr)
+    exitCode <- Process.waitExitCode process
+    pure (result, exitCode)
+
+streamFromFiles ::
+  String ->
+  TestConfig ->
+  ((Stream.Stream IO Text, Stream.Stream IO ByteString) -> IO r) ->
+  IO (r, Process.ExitCode)
+streamFromFiles name config use_stream = do
+  let suffix = if config.oldStyle then "" else ".json"
+  out <- readFileBS ("test/golden/" <> name <> "/stdout" <> suffix)
+  err <- readFileBS ("test/golden/" <> name <> "/stderr" <> suffix)
+  result <- use_stream (Stream.fromPure (decodeUtf8 out), Stream.fromPure err)
+  pure (result, Process.ExitSuccess)
+
 testBuild :: String -> TestConfig -> (Text -> NOMState -> IO ()) -> Test
 testBuild name config asserts =
   label config name ~: do
-    let suffix = if config.oldStyle then "" else ".json"
-        callNix = do
-          seed <- randomIO @Int
-          let command =
-                if config.oldStyle
-                  then
-                    Process.proc
-                      "nix-build"
-                      ["test/golden/" <> name <> "/default.nix", "--no-out-link", "--argstr", "seed", show seed]
-                  else
-                    Process.proc
-                      "nix"
-                      ["build", "-f", "test/golden/" <> name <> "/default.nix", "--no-link", "--argstr", "seed", show seed, "-v", "--log-format", "internal-json"]
-          Process.readProcess command
-            <&> (\(_, stdout', stderr') -> (decodeUtf8 stdout', toStrict stderr'))
-        readFiles = (,) . decodeUtf8 <$> readFileBS ("test/golden/" <> name <> "/stdout" <> suffix) <*> readFileBS ("test/golden/" <> name <> "/stderr" <> suffix)
-    (output, errors) <- if config.withNix then callNix else readFiles
-    end_state <- if config.oldStyle then testProcess @OldStyleInput (Stream.fromPure errors) else testProcess @NixJSONMessage (Stream.fromList (ByteString.lines errors))
-    onException (asserts output end_state) $ do
-      ByteString.putStrLn errors
-      print end_state
+    seed <- randomIO @Int
+    let go = if config.withNix then streamNixCommand config command else streamFromFiles name config
+         where
+            command =
+              if config.oldStyle
+                then
+                  Process.proc
+                    "nix-build"
+                    ["test/golden/" <> name <> "/default.nix", "--no-out-link", "--argstr", "seed", show seed]
+                else
+                  Process.proc
+                    "nix"
+                    ["build", "-f", "test/golden/" <> name <> "/default.nix", "--no-link", "--argstr", "seed", show seed, "-v", "--log-format", "internal-json"]
+
+    fst <$> go \(output, errors) -> do
+      end_state <- if config.oldStyle then testProcess @OldStyleInput errors else testProcess @NixJSONMessage errors
+      pure ()
+      -- TODO(leana8959): how do I consume the stream for the assertion without running IO twice?
+      -- onException (asserts output end_state) $ do
+      --   ByteString.putStrLn errors
+      --   print end_state
 
 testProcess :: forall input. (NOMInput input) => Stream.Stream IO ByteString -> IO NOMState
 testProcess input = withParser @input \streamParser -> do

--- a/test/Golden.hs
+++ b/test/Golden.hs
@@ -111,8 +111,8 @@ testBuild name config asserts =
                   ["test/golden/" <> name <> "/default.nix", "--no-out-link", "--argstr", "seed", show seed]
               else
                 Process.proc
-                  "nix"
-                  ["build", "-f", "test/golden/" <> name <> "/default.nix", "--no-link", "--argstr", "seed", show seed, "-v", "--log-format", "internal-json"]
+                  "nix-build"
+                  ["test/golden/" <> name <> "/default.nix", "--no-out-link", "--argstr", "seed", show seed, "-v", "--log-format", "internal-json"]
 
     (end_state, output, _) <- go (if config.oldStyle then testProcess @OldStyleInput else testProcess @NixJSONMessage)
     output' <- atomically output

--- a/test/Golden.hs
+++ b/test/Golden.hs
@@ -70,31 +70,31 @@ streamFromNixCommand ::
   TestConfig ->
   Process.ProcessConfig () () () ->
   (Stream.Stream IO ByteString -> IO r) ->
-  IO (r, STM Text, Process.ExitCode)
+  IO (r, Text, Process.ExitCode)
 streamFromNixCommand test_config process_config use_stream = do
   let process_config_with_handles =
         process_config
           & Process.setStdout Process.byteStringOutput
           & Process.setStderr Process.createPipe
   Process.withProcessWait process_config_with_handles \process -> do
-    let out = decodeUtf8 <$> Process.getStdout process
     let err = Stream.catRights $ (if test_config.oldStyle then inputStream OldStyleInput else inputStream NixJSONMessage) (Process.getStderr process)
     result <- use_stream err
     exitCode <- Process.waitExitCode process
-    pure (result, out, exitCode)
+    out <- atomically $ Process.getStdout process
+    pure (result, decodeUtf8 out, exitCode)
 
 -- Note: we don't care about the timing for this one, because the log is already pre-recorded. Changing this to streaming doesn't do anything to the timing issue we supposedly have with Lix.
 streamFromGoldenFiles ::
   String ->
   TestConfig ->
   (Stream.Stream IO ByteString -> IO r) ->
-  IO (r, STM Text, Process.ExitCode)
+  IO (r, Text, Process.ExitCode)
 streamFromGoldenFiles name config use_stream = do
   let suffix = if config.oldStyle then "" else ".json"
   out <- readFileBS ("test/golden/" <> name <> "/stdout" <> suffix)
   err <- readFileBS ("test/golden/" <> name <> "/stderr" <> suffix)
   result <- use_stream $ if config.oldStyle then Stream.fromPure err else Stream.fromList (ByteString.lines err)
-  pure (result, pure (decodeUtf8 out), Process.ExitSuccess)
+  pure (result, decodeUtf8 out, Process.ExitSuccess)
 
 testBuild :: String -> TestConfig -> (Text -> NOMState -> IO ()) -> Test
 testBuild name config asserts =
@@ -107,9 +107,8 @@ testBuild name config asserts =
               $ ["test/golden/" <> name <> "/default.nix", "--no-out-link", "--argstr", "seed", show seed]
               <> if config.oldStyle then [] else ["-v", "--log-format", "internal-json"]
 
-    (end_state, output_var, _) <- go if config.oldStyle then testProcess @OldStyleInput else testProcess @NixJSONMessage
+    (end_state, output, _) <- go if config.oldStyle then testProcess @OldStyleInput else testProcess @NixJSONMessage
 
-    output <- atomically output_var
     onException (asserts output end_state) $ do
       TextIO.putStrLn output
       print end_state

--- a/test/Golden.hs
+++ b/test/Golden.hs
@@ -3,8 +3,8 @@ module Main (main) where
 import Control.Concurrent (threadDelay)
 import Control.Exception (onException)
 import Control.Monad.Trans.Writer.CPS (runWriterT)
-import Data.ByteString.Char8 qualified as ByteString
 import Data.Text qualified as Text
+import Data.Text.IO qualified as TIO
 import NOM.Builds (parseStorePath)
 import NOM.Error (NOMError)
 import NOM.IO (processTextStream)
@@ -65,37 +65,36 @@ main = do
 
 data TestConfig = MkTestConfig {withNix :: Bool, oldStyle :: Bool}
 
-
 streamNixCommand ::
   TestConfig ->
   Process.ProcessConfig () () () ->
-  ((Stream.Stream IO Text, Stream.Stream IO ByteString) -> IO r) ->
-  IO (r, Process.ExitCode)
+  (Stream.Stream IO ByteString -> IO r) ->
+  IO (r, STM Text, Process.ExitCode)
 streamNixCommand test_config process_config use_stream = do
   let process_config_with_handles =
-        Process.setStdout Process.createPipe
+        Process.setStdout Process.byteStringOutput
           . Process.setStderr Process.createPipe
           $ process_config
   Process.withProcessWait @IO process_config_with_handles \process -> do
-    let stdout = Stream.catRights $ (if test_config.oldStyle then inputStream OldStyleInput else inputStream NixJSONMessage) (Process.getStdout process)
-    let stderr = Stream.catRights $ (if test_config.oldStyle then inputStream OldStyleInput else inputStream NixJSONMessage) (Process.getStderr process)
+    let out = decodeUtf8 <$> Process.getStdout process
+    let err = Stream.catRights $ (if test_config.oldStyle then inputStream OldStyleInput else inputStream NixJSONMessage) (Process.getStderr process)
 
     -- TODO(leana8959): deal with the errors within the streams
-    result <- use_stream (decodeUtf8 <$> stdout, stderr)
+    result <- use_stream err
     exitCode <- Process.waitExitCode process
-    pure (result, exitCode)
+    pure (result, out, exitCode)
 
 streamFromFiles ::
   String ->
   TestConfig ->
-  ((Stream.Stream IO Text, Stream.Stream IO ByteString) -> IO r) ->
-  IO (r, Process.ExitCode)
+  (Stream.Stream IO ByteString -> IO r) ->
+  IO (r, STM Text, Process.ExitCode)
 streamFromFiles name config use_stream = do
   let suffix = if config.oldStyle then "" else ".json"
   out <- readFileBS ("test/golden/" <> name <> "/stdout" <> suffix)
   err <- readFileBS ("test/golden/" <> name <> "/stderr" <> suffix)
-  result <- use_stream (Stream.fromPure (decodeUtf8 out), Stream.fromPure err)
-  pure (result, Process.ExitSuccess)
+  result <- use_stream (Stream.fromPure err)
+  pure (result, pure (decodeUtf8 out), Process.ExitSuccess)
 
 testBuild :: String -> TestConfig -> (Text -> NOMState -> IO ()) -> Test
 testBuild name config asserts =
@@ -103,24 +102,24 @@ testBuild name config asserts =
     seed <- randomIO @Int
     let go = if config.withNix then streamNixCommand config command else streamFromFiles name config
          where
-            command =
-              if config.oldStyle
-                then
-                  Process.proc
-                    "nix-build"
-                    ["test/golden/" <> name <> "/default.nix", "--no-out-link", "--argstr", "seed", show seed]
-                else
-                  Process.proc
-                    "nix"
-                    ["build", "-f", "test/golden/" <> name <> "/default.nix", "--no-link", "--argstr", "seed", show seed, "-v", "--log-format", "internal-json"]
+          command =
+            if config.oldStyle
+              then
+                Process.proc
+                  "nix-build"
+                  ["test/golden/" <> name <> "/default.nix", "--no-out-link", "--argstr", "seed", show seed]
+              else
+                Process.proc
+                  "nix"
+                  ["build", "-f", "test/golden/" <> name <> "/default.nix", "--no-link", "--argstr", "seed", show seed, "-v", "--log-format", "internal-json"]
 
-    fst <$> go \(output, errors) -> do
-      end_state <- if config.oldStyle then testProcess @OldStyleInput errors else testProcess @NixJSONMessage errors
-      pure ()
-      -- TODO(leana8959): how do I consume the stream for the assertion without running IO twice?
-      -- onException (asserts output end_state) $ do
-      --   ByteString.putStrLn errors
-      --   print end_state
+    (end_state, output, _) <- go (if config.oldStyle then testProcess @OldStyleInput else testProcess @NixJSONMessage)
+    output' <- atomically $ output
+
+    -- TODO(leana8959): how do I consume the stream for the assertion without running IO twice?
+    onException (asserts output' end_state) $ do
+      TIO.putStrLn output'
+      print end_state
 
 testProcess :: forall input. (NOMInput input) => Stream.Stream IO ByteString -> IO NOMState
 testProcess input = withParser @input \streamParser -> do

--- a/test/Golden.hs
+++ b/test/Golden.hs
@@ -99,9 +99,10 @@ testBuild name config asserts =
     let go = if config.withNix then streamFromNixCommand config command else streamFromGoldenFiles name config
          where
           command =
-            Process.proc "nix-build"
+            Process.proc
+              "nix-build"
               ( ["test/golden/" <> name <> "/default.nix", "--no-out-link", "--argstr", "seed", show seed]
-              <> if config.oldStyle then [] else ["-v", "--log-format", "internal-json"]
+                  <> if config.oldStyle then [] else ["-v", "--log-format", "internal-json"]
               )
               & Process.setStdout Process.byteStringOutput
               & Process.setStderr Process.createPipe

--- a/test/Golden.hs
+++ b/test/Golden.hs
@@ -40,6 +40,7 @@ import Test.HUnit (
   runTestTT,
   (~:),
  )
+import Data.ByteString.Char8 qualified as ByteString
 
 tests :: [TestConfig -> Test]
 tests = [goldenStandard, goldenFail]

--- a/test/Golden.hs
+++ b/test/Golden.hs
@@ -83,6 +83,7 @@ streamFromNixCommand test_config process_config use_stream = do
     exitCode <- Process.waitExitCode process
     pure (result, out, exitCode)
 
+-- Note: we don't care about the timing for this one, because the log is already pre-recorded. Changing this to streaming doesn't do anything to the timing issue we supposedly have with Lix.
 streamFromGoldenFiles ::
   String ->
   TestConfig ->
@@ -106,7 +107,7 @@ testBuild name config asserts =
               $ ["test/golden/" <> name <> "/default.nix", "--no-out-link", "--argstr", "seed", show seed]
               <> if config.oldStyle then [] else ["-v", "--log-format", "internal-json"]
 
-    (end_state, output_var, _) <- go (if config.oldStyle then testProcess @OldStyleInput else testProcess @NixJSONMessage)
+    (end_state, output_var, _) <- go if config.oldStyle then testProcess @OldStyleInput else testProcess @NixJSONMessage
 
     output <- atomically output_var
     onException (asserts output end_state) $ do

--- a/test/Golden.hs
+++ b/test/Golden.hs
@@ -3,8 +3,9 @@ module Main (main) where
 import Control.Concurrent (threadDelay)
 import Control.Exception (onException)
 import Control.Monad.Trans.Writer.CPS (runWriterT)
+import Data.ByteString.Char8 qualified as ByteString
 import Data.Text qualified as Text
-import Data.Text.IO qualified as TIO
+import Data.Text.IO qualified as TextIO
 import NOM.Builds (parseStorePath)
 import NOM.Error (NOMError)
 import NOM.IO (processTextStream)
@@ -40,7 +41,6 @@ import Test.HUnit (
   runTestTT,
   (~:),
  )
-import Data.ByteString.Char8 qualified as ByteString
 
 tests :: [TestConfig -> Test]
 tests = [goldenStandard, goldenFail]
@@ -115,11 +115,11 @@ testBuild name config asserts =
                   ["build", "-f", "test/golden/" <> name <> "/default.nix", "--no-link", "--argstr", "seed", show seed, "-v", "--log-format", "internal-json"]
 
     (end_state, output, _) <- go (if config.oldStyle then testProcess @OldStyleInput else testProcess @NixJSONMessage)
-    output' <- atomically $ output
+    output' <- atomically output
 
     -- TODO(leana8959): how do I consume the stream for the assertion without running IO twice?
     onException (asserts output' end_state) $ do
-      TIO.putStrLn output'
+      TextIO.putStrLn output'
       print end_state
 
 testProcess :: forall input. (NOMInput input) => Stream.Stream IO ByteString -> IO NOMState

--- a/test/Golden.hs
+++ b/test/Golden.hs
@@ -80,7 +80,6 @@ streamNixCommand test_config process_config use_stream = do
     let out = decodeUtf8 <$> Process.getStdout process
     let err = Stream.catRights $ (if test_config.oldStyle then inputStream OldStyleInput else inputStream NixJSONMessage) (Process.getStderr process)
 
-    -- TODO(leana8959): deal with the errors within the streams
     result <- use_stream err
     exitCode <- Process.waitExitCode process
     pure (result, out, exitCode)


### PR DESCRIPTION
I think it'd still be nice to stream the nix command's output to nom during testing. These tests pass on my machine and I'm using lix, but hopefully with a better reproducer / golden test added to this framework we can catch the errors that lix users were having in the first place.

I also refactored the usage of nix-command `nix build`. Old nix-build can do the same. 