### PR TITLE
Add doctests

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,9 +1,9 @@
 { mkDerivation, ansi-terminal, async, attoparsec, base, bytestring
-, cassava, containers, directory, extra, filelock, filepath
-, fsnotify, hermes-json, HUnit, lib, nix-derivation, optics, random
-, relude, safe, safe-exceptions, stm, streamly-core, strict
-, terminal-size, text, time, transformers, typed-process, unix
-, word8
+, cassava, containers, directory, doctest-parallel, extra, filelock
+, filepath, fsnotify, hermes-json, HUnit, lib, nix-derivation
+, optics, random, relude, safe, safe-exceptions, stm, streamly-core
+, strict, terminal-size, text, time, transformers, typed-process
+, unix, word8
 }:
 mkDerivation {
   pname = "nix-output-monitor";
@@ -26,10 +26,10 @@ mkDerivation {
   ];
   testHaskellDepends = [
     ansi-terminal async attoparsec base bytestring cassava containers
-    directory extra filelock filepath fsnotify hermes-json HUnit
-    nix-derivation optics random relude safe safe-exceptions stm
-    streamly-core strict terminal-size text time transformers
-    typed-process word8
+    directory doctest-parallel extra filelock filepath fsnotify
+    hermes-json HUnit nix-derivation optics random relude safe
+    safe-exceptions stm streamly-core strict terminal-size text time
+    transformers typed-process word8
   ];
   homepage = "https://code.maralorn.de/maralorn/nix-output-monitor";
   description = "Processes output of Nix commands to show helpful and pretty information";

--- a/lib/NOM/Print.hs
+++ b/lib/NOM/Print.hs
@@ -1,4 +1,4 @@
-module NOM.Print (stateToText, showCode, Config (..)) where
+module NOM.Print (stateToText, showCode, Config (..), showCond) where
 
 import Data.Foldable qualified as Unsafe
 import Data.IntMap.Strict qualified as IntMap
@@ -101,6 +101,14 @@ average = "∅"
 -- | U+2211 N-ARY SUMMATION
 bigsum = "∑"
 
+{- |
+>>> import Relude
+>>> showCond True "foo"
+"foo"
+
+>>> showCond False "foo"
+""
+-}
 showCond :: (Monoid m) => Bool -> m -> m
 showCond = memptyIfFalse
 

--- a/nix-output-monitor.cabal
+++ b/nix-output-monitor.cabal
@@ -180,3 +180,12 @@ test-suite golden-tests
   build-depends: random
   type: exitcode-stdio-1.0
   main-is: Golden.hs
+
+test-suite doc-tests
+  import: tests
+  build-depends:
+    doctest-parallel
+
+  type: exitcode-stdio-1.0
+  main-is: Doctests.hs
+  hs-source-dirs: test

--- a/test/Doctests.hs
+++ b/test/Doctests.hs
@@ -1,0 +1,7 @@
+module Main (main) where
+
+import Relude
+import Test.DocTest (mainFromCabal)
+
+main :: IO ()
+main = mainFromCabal "nix-output-monitor" =<< getArgs


### PR DESCRIPTION
This is just a very simple proof of concept. But the point is: It works.

cabal run -- doc-tests

works on the terminal and they also run in

nix build.

Only caveat is this uses doctest-parallel (instead of the original doctest) which does not interpret snippets in the context of the module they are in, but just imports that module, so all tested functions need to be exported. But since this is required for other tests as well I don’t think it hurts much.