### PR TITLE
Add 'nom flake' subcommand

### DIFF
--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -93,6 +93,7 @@ runApp = \cases
   "nom" ("develop" : args) -> do
     exitOnFailure =<< runMonitoredCommand defaultConfig{silent = True} (proc "nix" ("develop" : withJSON (replaceCommandWithExit args)))
     exitWith =<< runProcess (proc "nix" ("develop" : args))
+  "nom" ("flake" : args) -> exitWith =<< runMonitoredCommand defaultConfig (proc "nix" ("flake" : withJSON args))
   "nom" [] -> do
     finalState <- monitorHandle OldStyleInput defaultConfig{piping = True} stdin
     if CMap.size finalState.fullSummary.failedBuilds + length finalState.nixErrors == 0


### PR DESCRIPTION
This is my attempt to address https://github.com/maralorn/nix-output-monitor/issues/106. I'm pretty new to the codebase so I just copied what we're already doing for `nom build` and `nom copy`.